### PR TITLE
Update `InlineArray+sugar.swift`

### DIFF
--- a/Sources/QizhKit/Extensions/Collection+/InlineArray+sugar.swift
+++ b/Sources/QizhKit/Extensions/Collection+/InlineArray+sugar.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-// #if swift(>=6.2)
+#if swift(>=6.2)
 
 @available(iOS 26.0, *)
 extension InlineArray {
@@ -60,4 +60,4 @@ public struct InlineArrayCollection<let N: Int, Element>: RandomAccessCollection
 	public subscript(pos: Int) -> Element { base[pos] }
 }
 
-// #endif
+#endif


### PR DESCRIPTION
Turn Swift version >= 6.2 condition back on to avoid errors when building with Swift 6.1. 