### PR TITLE
Add Airtable formula builder tests and update coverage checklist

### DIFF
--- a/Docs/TESTS_COVERAGE.md
+++ b/Docs/TESTS_COVERAGE.md
@@ -1,491 +1,104 @@
 # Test Coverage Planning
 
-This document tracks unit-test candidates discovered while scanning the QizhKit codebase, grouped by source area. Each entry lists the public APIs worth covering and concrete test ideas to validate their behavior.
+This document tracks unit-test candidates discovered while scanning the QizhKit codebase, grouped by source area. Each entry lists the public APIs worth covering and concrete test ideas to validate their behavior. Checkboxes track implementation status.
 
-## ⊞ [Components/Airtable/AirtableFormulaBuilder.swift](Components/Airtable/AirtableFormulaBuilder.swift)
+## Components/Airtable/AirtableFormulaBuilder.swift
+- [x] File: [Components/Airtable/AirtableFormulaBuilder.swift](Components/Airtable/AirtableFormulaBuilder.swift)
+  - Public entities to cover
+    - [x] `String.StringInterpolation.appendInterpolation(_:)` overloads for formulas and apostrophe escaping
+    - [x] `String.withApostrophesEscaped` helper
+  - Candidate tests
+    - [x] `testProducesAirtableFriendlyStrings` — APIs: `.equals`, `.notEquals`, `.isEmpty`, `.id`. Produce Airtable-friendly strings.
+    - [x] `testCombinesFormulasWithAndOrNot` — APIs: `.and`, `.or`, `.not`. Validate `.and`, `.or`, and `.not` nest descriptions correctly for multiple children.
+    - [x] `testEscapesApostrophesInInterpolation` — APIs: `appendInterpolation(_:)`, `withApostrophesEscaped`. Verify the custom string interpolation paths escape single quotes consistently for raw values and `RawRepresentable` inputs.
 
-<table>
-  <tr>
-    <th>Public entities to cover</th>
-    <th>Candidate tests</th>
-  </tr>
-  <tr>
-    <td>
-      
-- `String.StringInterpolation.appendInterpolation(_:)` overloads for formulas and apostrophe escaping
-- `String.withApostrophesEscaped` helper
-    </td>
-    <td>
-      <table>
-        <tr>
-          <th alignment="leading">Name</th>
-          <th>APIs to test</th>
-          <th>Description</th>
-        </tr>
-        <tr>                             <!-- ╭────┘ 1 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testProducesAirtableFriendlyStrings`
-          </td>
-          <td>                           <!-- ├ 𝘼𝙋𝙄𝙨 𝙩𝙤 𝙩𝙚𝙨𝙩     │ -->
-`.equals`, `.notEquals`, `.isEmpty`, and `.id`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Produce Airtable-friendly strings
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 2 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testCombinesFormulasWithAndOrNot`
-          </td>
-          <td>                           <!-- ├ 𝘼𝙋𝙄𝙨 𝙩𝙤 𝙩𝙚𝙨𝙩     │ -->
-`.and`, `.or`, `.not`
-          </td>
-          <td>                           <!-- ├❴ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣 ❵────┤ -->
-Validate `.and`, `.or`, and `.not` nest descriptions correctly for multiple children
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 3 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testEscapesApostrophesInInterpolation`
-          </td>
-          <td>                           <!-- ├ 𝘼𝙋𝙄𝙨 𝙩𝙤 𝙩𝙚𝙨𝙩     │ -->
-`appendInterpolation(_:)`, `withApostrophesEscaped`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Verify the custom string interpolation paths escape single quotes consistently for raw values and `RawRepresentable` inputs
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-      </table>
-    </td>
-  </tr>
-</table>
+## Components/Random Generators/SeededRandomGenerator.swift
+- [ ] File: [Components/Random Generators/SeededRandomGenerator.swift](Components/Random%20Generators/SeededRandomGenerator.swift)
+  - Public entities to cover
+    - [ ] `SeededRandomGenerator` seeding behavior and `next()` production
+  - Candidate tests
+    - [ ] `testProducesRepeatableSequence` — Confirm identical seeds emit identical sequences across multiple draws.
+    - [ ] `testMixes64BitOutput` — Assert two 32-bit GK samples are combined into varying high/low bits to prevent bias.
+    - [ ] `testAdvancesStateBetweenCalls` — Ensure successive `next()` calls mutate generator state (no repeated constant).
 
-## ⊞ [Components/Random Generators/SeededRandomGenerator.swift](Components/Random%20Generators/SeededRandomGenerator.swift)
+## Extensions/String+/String+modify.swift
+- [ ] File: [Extensions/String+/String+modify.swift](Extensions/String+/String+modify.swift)
+  - Public entities to cover
+    - [ ] `StringProtocol` replacement/trim utilities (`replacing`, `withSpacesTrimmed`, `withLinesTrimmed`, `withEmptyLinesTrimmed`, `withLinesNSpacesTrimmed`, `digits`)
+    - [ ] Trailing trimming helpers (`trimmingTrailingCharacters`, `withTrailingSpacesTrimmed`, `withTrailingSpacesAndLinesTrimmed`)
+    - [ ] Multiplication operator `String * UInt`
+    - [ ] `StringOffset` presets and properties
+    - [ ] Line offsetting helpers (`offsetting`, `offsettingLines`, `offsettingNewLines`, `tabOffsettingLines`, `tabOffsettingNewLines`)
+  - Candidate tests
+    - [ ] `testReplacesAndTrimsStrings` — Cover replacements by set/value and trimming behaviors including empty-line removal.
+    - [ ] `testTrimsTrailingCharacters` — Verify targeted trailing whitespace/newline removal paths.
+    - [ ] `testRepeatsStringWithMultiplicationOperator` — Ensure `"abc" * 3` returns expected concatenation.
+    - [ ] `testStringOffsetPresetsEmitExpectedTokens` — Validate `StringOffset` preset suffix/prefix strings and computed properties.
+    - [ ] `testOffsetsMultilineBlocks` — Assert offsetting helpers pad each line as documented.
 
-<table>
-  <tr>
-    <th>Public entities to cover</th>
-    <th>Candidate tests</th>
-  </tr>
-  <tr>
-    <td>
+## Structures/Dimensions/GeometryReceivers.swift
+- [ ] File: [Structures/Dimensions/GeometryReceivers.swift](Structures/Dimensions/GeometryReceivers.swift)
+  - Public entities to cover
+    - [ ] View extensions `receiveWidth`, `receiveHeight`, `receiveSafeAreaInsets` for callback and binding variants
+  - Candidate tests
+    - [ ] `testCapturesWidthAndHeightPreferences` — Inject test views and confirm bindings receive geometry values once layout occurs.
+    - [ ] `testInvokesCallbacksOnChange` — Ensure callbacks fire with updated dimensions when layout changes.
+    - [ ] `testBindsOptionalAndNonoptionalInsets` — Verify both `EdgeInsets` and `EdgeInsets?` bindings are updated through the preference chain.
 
-- `SeededRandomGenerator` seeding behavior and `next()` production
-    </td>
-    <td>
-      <table>
-        <tr>
-          <th alignment="leading">Name</th>
-          <th>Description</th>
-        </tr>
-        <tr>                             <!-- ╭────┘ 1 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testProducesRepeatableSequence`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Confirm identical seeds emit identical sequences across multiple draws
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 2 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testMixes64BitOutput`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Assert two 32-bit GK samples are combined into varying high/low bits to prevent bias
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 3 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testAdvancesStateBetweenCalls`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Ensure successive `next()` calls mutate generator state (no repeated constant)
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-      </table>
-    </td>
-  </tr>
-</table>
+## Structures/Dimensions/RelativeDimension.swift
+- [ ] File: [Structures/Dimensions/RelativeDimension.swift](Structures/Dimensions/RelativeDimension.swift)
+  - Public entities to cover
+    - [ ] `RelativeDimension` literal conformance and stored cases (`maximum`, `exactly`, `minimum`)
+    - [ ] Computed values (`value`, `maxValue`, `extraPadding`)
+    - [ ] Comparison helpers (`is(_:)`, `isMaximum`, `isExact`, `isMinimum`)
+  - Candidate tests
+    - [ ] `testInitializesFromLiterals` — Confirm float/integer literal initializers map to `.exactly` with converted `CGFloat`.
+    - [ ] `testExposesValueAndMaxValue` — Validate optional outputs for `exactly` vs `maximum` cases.
+    - [ ] `testMinimumCaseReportsPadding` — Ensure `.minimum` carries the provided padding.
+    - [ ] `testComparisonHelpersMatchCases` — Test `is` and convenience flags across all permutations.
 
-## ⊞ [Extensions/String+/String+modify.swift](Extensions/String+/String+modify.swift)
+## Structures/Type Erase/AnyComparable.swift
+- [ ] File: [Structures/Type Erase/AnyComparable.swift](Structures/Type%20Erase/AnyComparable.swift)
+  - Public entities to cover
+    - [ ] `AnyComparable` boxing behavior
+    - [ ] `Comparable`/`Equatable` conformance
+    - [ ] `Comparable.asAnyComparable()` helper
+  - Candidate tests
+    - [ ] `testComparesBoxedValues` — Assert `<` and `==` use underlying `Comparable` semantics for same-typed boxes.
+    - [ ] `testHandlesCrossTypeComparisonsSafely` — Ensure comparisons with different underlying types return `false` without crashes.
+    - [ ] `testWrapsComparableValues` — Verify `.asAnyComparable()` wraps and preserves ordering in sorted collections.
 
-<table>
-  <tr>
-    <th>Public entities to cover</th>
-    <th>Candidate tests</th>
-  </tr>
-  <tr>
-    <td>
+## Structures/Type Erase/AnyHashableAndSendable.swift
+- [ ] File: [Structures/Type Erase/AnyHashableAndSendable.swift](Structures/Type%20Erase/AnyHashableAndSendable.swift)
+  - Public entities to cover
+    - [ ] Property wrappers `AnyHashableAndSendable`, `AnySendableEncodable`, `AnyHashableSendableEncodable` and their nested box types
+    - [ ] Protocols (`HashableAndSendableAdoptable`, `SendableEncodableAdoptable`, `HashableSendableEncodableAdoptable`)
+    - [ ] Encoding helpers on `[AnyHashable: Any]` (`asEncodedJsonString`, `asEncodedJson5string`)
+  - Candidate tests
+    - [ ] `testBoxesPreserveHashAndEquality` — Verify wrappers round-trip `Hashable`/`Sendable` values and compare correctly across identical and differing types.
+    - [ ] `testEncodesWrappedValues` — Ensure encodable wrappers forward encoding to the underlying value and produce expected JSON/JSON5 strings.
+    - [ ] `testSupportsPropertyWrapperInitStyles` — Cover both `init(wrappedValue:)` and direct initializers for each wrapper.
+    - [ ] `testHandlesNonEncodableDictionaryEntries` — Assert encoding helpers return the fallback message when dictionary cannot be cast to `Encodable`.
 
-- `StringProtocol` replacement/trim utilities (`replacing`, `withSpacesTrimmed`, `withLinesTrimmed`, `withEmptyLinesTrimmed`, `withLinesNSpacesTrimmed`, `digits`)
-- Trailing trimming helpers (`trimmingTrailingCharacters`, `withTrailingSpacesTrimmed`, `withTrailingSpacesAndLinesTrimmed`)
-- Multiplication operator `String * UInt`
-- `StringOffset` presets and properties
-- Line offsetting helpers (`offsetting`, `offsettingLines`, `offsettingNewLines`, `tabOffsettingLines`, `tabOffsettingNewLines`)
-    </td>
-    <td>
-      <table>
-        <tr>
-          <th alignment="leading">Name</th>
-          <th>Description</th>
-        </tr>
-        <tr>                             <!-- ╭────┘ 1 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testReplacesAndTrimsStrings`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Cover replacements by set/value and trimming behaviors including empty-line removal
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 2 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testTrimsTrailingCharacters`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Verify targeted trailing whitespace/newline removal paths
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 3 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testRepeatsStringWithMultiplicationOperator`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Ensure `"abc" * 3` returns expected concatenation
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 4 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testStringOffsetPresetsEmitExpectedTokens`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Validate `StringOffset` preset suffix/prefix strings and computed properties
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 5 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testOffsetsMultilineBlocks`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Assert offsetting helpers pad each line as documented
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-      </table>
-    </td>
-  </tr>
-</table>
+## Ugly/WindowUtils.swift
+- [ ] File: [Ugly/WindowUtils.swift](Ugly/WindowUtils.swift)
+  - Public entities to cover
+    - [ ] `WindowUtils` window accessors (`setOriginalWindow`, `windowScene`, `keyWindow`, `rootViewController`, `originalWindow`, `currentWindow`, `topViewController`)
+    - [ ] Global helpers `endEditing(force:)` and `SafeFrame.currentInsets`
+  - Candidate tests
+    - [ ] `testTracksManuallyAssignedWindow` — Confirm `setOriginalWindow` overrides lookup and restores when cleared.
+    - [ ] `testResolvesTopViewController` — Simulate navigation/tab/presentation stacks to ensure the traversal selects the visible controller.
+    - [ ] `testEndsEditingThroughCurrentWindow` — Verify `endEditing(force:)` relays to the active window and respects the `force` flag.
+    - [ ] `testReportsSafeAreaInsets` — Validate `SafeFrame.currentInsets` mirrors the active window's safe area.
 
-## ⊞ [Structures/Dimensions/GeometryReceivers.swift](Structures/Dimensions/GeometryReceivers.swift)
-
-<table>
-  <tr>
-    <th>Public entities to cover</th>
-    <th>Candidate tests</th>
-  </tr>
-  <tr>
-    <td>
-
-- View extensions `receiveWidth`, `receiveHeight`, `receiveSafeAreaInsets` for callback and binding variants
-    </td>
-    <td>
-      <table>
-        <tr>
-          <th alignment="leading">Name</th>
-          <th>Description</th>
-        </tr>
-        <tr>                             <!-- ╭────┘ 1 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testCapturesWidthAndHeightPreferences`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Inject test views and confirm bindings receive geometry values once layout occurs
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 2 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testInvokesCallbacksOnChange`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Ensure callbacks fire with updated dimensions when layout changes
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 3 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testBindsOptionalAndNonoptionalInsets`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Verify both `EdgeInsets` and `EdgeInsets?` bindings are updated through the preference chain
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-      </table>
-    </td>
-  </tr>
-</table>
-
-## ⊞ [Structures/Dimensions/RelativeDimension.swift](Structures/Dimensions/RelativeDimension.swift)
-
-<table>
-  <tr>
-    <th>Public entities to cover</th>
-    <th>Candidate tests</th>
-  </tr>
-  <tr>
-    <td>
-
-- `RelativeDimension` literal conformance and stored cases (`maximum`, `exactly`, `minimum`)
-- Computed values (`value`, `maxValue`, `extraPadding`)
-- Comparison helpers (`is(_:)`, `isMaximum`, `isExact`, `isMinimum`)
-    </td>
-    <td>
-      <table>
-        <tr>
-          <th alignment="leading">Name</th>
-          <th>Description</th>
-        </tr>
-        <tr>                             <!-- ╭────┘ 1 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testInitializesFromLiterals`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Confirm float/integer literal initializers map to `.exactly` with converted `CGFloat`
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 2 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testExposesValueAndMaxValue`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Validate optional outputs for `exactly` vs `maximum` cases
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 3 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testMinimumCaseReportsPadding`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Ensure `.minimum` carries the provided padding
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 4 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testComparisonHelpersMatchCases`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Test `is` and convenience flags across all permutations
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-      </table>
-    </td>
-  </tr>
-</table>
-
-## ⊞ [Structures/Type Erase/AnyComparable.swift](Structures/Type%20Erase/AnyComparable.swift)
-
-<table>
-  <tr>
-    <th>Public entities to cover</th>
-    <th>Candidate tests</th>
-  </tr>
-  <tr>
-    <td>
-
-- `AnyComparable` boxing behavior
-- `Comparable`/`Equatable` conformance
-- `Comparable.asAnyComparable()` helper
-    </td>
-    <td>
-      <table>
-        <tr>
-          <th alignment="leading">Name</th>
-          <th>Description</th>
-        </tr>
-        <tr>                             <!-- ╭────┘ 1 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testComparesBoxedValues`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Assert `<` and `==` use underlying `Comparable` semantics for same-typed boxes
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 2 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testHandlesCrossTypeComparisonsSafely`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Ensure comparisons with different underlying types return `false` without crashes
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 3 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testWrapsComparableValues`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Verify `.asAnyComparable()` wraps and preserves ordering in sorted collections
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-      </table>
-    </td>
-  </tr>
-</table>
-
-## ⊞ [Structures/Type Erase/AnyHashableAndSendable.swift](Structures/Type%20Erase/AnyHashableAndSendable.swift)
-
-<table>
-  <tr>
-    <th>Public entities to cover</th>
-    <th>Candidate tests</th>
-  </tr>
-  <tr>
-    <td>
-
-- Property wrappers `AnyHashableAndSendable`, `AnySendableEncodable`, `AnyHashableSendableEncodable` and their nested box types
-- Protocols (`HashableAndSendableAdoptable`, `SendableEncodableAdoptable`, `HashableSendableEncodableAdoptable`)
-- Encoding helpers on `[AnyHashable: Any]` (`asEncodedJsonString`, `asEncodedJson5string`)
-    </td>
-    <td>
-      <table>
-        <tr>
-          <th alignment="leading">Name</th>
-          <th>Description</th>
-        </tr>
-        <tr>                             <!-- ╭────┘ 1 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testBoxesPreserveHashAndEquality`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Verify wrappers round-trip `Hashable`/`Sendable` values and compare correctly across identical and differing types
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 2 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testEncodesWrappedValues`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Ensure encodable wrappers forward encoding to the underlying value and produce expected JSON/JSON5 strings
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 3 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testSupportsPropertyWrapperInitStyles`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Cover both `init(wrappedValue:)` and direct initializers for each wrapper
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 4 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testHandlesNonEncodableDictionaryEntries`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Assert encoding helpers return the fallback message when dictionary cannot be cast to `Encodable`
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-      </table>
-    </td>
-  </tr>
-</table>
-
-## ⊞ [Ugly/WindowUtils.swift](Ugly/WindowUtils.swift)
-
-<table>
-  <tr>
-    <th>Public entities to cover</th>
-    <th>Candidate tests</th>
-  </tr>
-  <tr>
-    <td>
-
-- `WindowUtils` window accessors (`setOriginalWindow`, `windowScene`, `keyWindow`, `rootViewController`, `originalWindow`, `currentWindow`, `topViewController`)
-- Global helpers `endEditing(force:)` and `SafeFrame.currentInsets`
-    </td>
-    <td>
-      <table>
-        <tr>
-          <th alignment="leading">Name</th>
-          <th>Description</th>
-        </tr>
-        <tr>                             <!-- ╭────┘ 1 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testTracksManuallyAssignedWindow`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Confirm `setOriginalWindow` overrides lookup and restores when cleared
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 2 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testResolvesTopViewController`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Simulate navigation/tab/presentation stacks to ensure the traversal selects the visible controller
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 3 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testEndsEditingThroughCurrentWindow`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Verify `endEditing(force:)` relays to the active window and respects the `force` flag
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 4 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testReportsSafeAreaInsets`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Validate `SafeFrame.currentInsets` mirrors the active window's safe area
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-      </table>
-    </td>
-  </tr>
-</table>
-
-## ⊞ [Third Party/Pluralize/Pluralize.swift](Third%20Party/Pluralize/Pluralize.swift)
-
-<table>
-  <tr>
-    <th>Public entities to cover</th>
-    <th>Candidate tests</th>
-  </tr>
-  <tr>
-    <td>
-
-- `Pluralize` class API (`apply`, `applySingular`, `rule`, `singularRule`, `uncountable`, `unchanging`, instance rule collections)
-    </td>
-    <td>
-      <table>
-        <tr>
-          <th alignment="leading">Name</th>
-          <th>Description</th>
-        </tr>
-        <tr>                             <!-- ╭────┘ 1 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testPluralizesAndSingularizesCommonWords`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Check irregular and regular transformations for representative samples
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 2 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testHonorsUncountableAndUnchangingLists`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Confirm words in those collections return unchanged results
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-        <tr>                             <!-- ╭────┘ 3 └───────╮ -->
-          <td>                           <!-- ├ 𝙉𝙖𝙢𝙚           │ -->
-`testAddsRuntimeRules`
-          </td>
-          <td>                           <!-- ├ 𝘿𝙚𝙨𝙘𝙧𝙞𝙥𝙩𝙞𝙤𝙣       │ -->
-Ensure dynamically added plural/singular rules apply ahead of defaults
-          </td>
-        </tr>                            <!-- ╰────────────────╯ -->
-      </table>
-    </td>
-  </tr>
-</table>
+## Third Party/Pluralize/Pluralize.swift
+- [ ] File: [Third Party/Pluralize/Pluralize.swift](Third%20Party/Pluralize/Pluralize.swift)
+  - Public entities to cover
+    - [ ] `Pluralize` class API (`apply`, `applySingular`, `rule`, `singularRule`, `uncountable`, `unchanging`, instance rule collections`)
+  - Candidate tests
+    - [ ] `testPluralizesAndSingularizesCommonWords` — Check irregular and regular transformations for representative samples.
+    - [ ] `testHonorsUncountableAndUnchangingLists` — Confirm words in those collections return unchanged results.
+    - [ ] `testAddsRuntimeRules` — Ensure dynamically added plural/singular rules apply ahead of defaults.
 
 ---
 

--- a/Docs/TESTS_COVERAGE.md
+++ b/Docs/TESTS_COVERAGE.md
@@ -94,7 +94,7 @@ This document tracks unit-test candidates discovered while scanning the QizhKit 
 ## Third Party/Pluralize/Pluralize.swift
 - [ ] File: [Third Party/Pluralize/Pluralize.swift](Third%20Party/Pluralize/Pluralize.swift)
   - Public entities to cover
-    - [ ] `Pluralize` class API (`apply`, `applySingular`, `rule`, `singularRule`, `uncountable`, `unchanging`, instance rule collections`)
+    - [ ] `Pluralize` class API (`apply`, `applySingular`, `rule`, `singularRule`, `uncountable`, `unchanging`, instance rule collections)
   - Candidate tests
     - [ ] `testPluralizesAndSingularizesCommonWords` — Check irregular and regular transformations for representative samples.
     - [ ] `testHonorsUncountableAndUnchangingLists` — Confirm words in those collections return unchanged results.

--- a/Tests/QizhKitTests/AirtableFormulaBuilderTests.swift
+++ b/Tests/QizhKitTests/AirtableFormulaBuilderTests.swift
@@ -10,7 +10,7 @@ struct AirtableFormulaBuilderTests {
                 case city
         }
 
-        @Test
+        @Test("Friendly strings producing")
         func testProducesAirtableFriendlyStrings() {
                 let equals = AirtableFormulaBuilder.equals("O'Hara", in: Fields.name)
                 let notEquals = AirtableFormulaBuilder.notEquals("O'Hara", in: Fields.name)
@@ -23,7 +23,7 @@ struct AirtableFormulaBuilderTests {
                 #expect(recordID.description == "RECORD_ID() = 'recABC123'")
         }
 
-        @Test
+        @Test("Using And or Not to combine formulas")
         func testCombinesFormulasWithAndOrNot() {
                 let emptyCheck = AirtableFormulaBuilder.isEmpty(Fields.city)
                 let nameEquals = AirtableFormulaBuilder.equals("Jean", in: Fields.name)
@@ -38,7 +38,7 @@ struct AirtableFormulaBuilderTests {
                 #expect(combined.description == "AND({name} = 'Jean', NOT({city} = BLANK()), OR(RECORD_ID() = 'rec1', RECORD_ID() = 'rec2'))")
         }
 
-        @Test
+        @Test("Escaping apostrophes in interpolation")
         func testEscapesApostrophesInInterpolation() {
                 enum Borough: String { case queens = "Queen's" }
 

--- a/Tests/QizhKitTests/AirtableFormulaBuilderTests.swift
+++ b/Tests/QizhKitTests/AirtableFormulaBuilderTests.swift
@@ -1,0 +1,55 @@
+#if swift(>=6.2) && canImport(Testing)
+
+import Testing
+import QizhKit
+
+@Suite("AirtableFormulaBuilder Tests")
+struct AirtableFormulaBuilderTests {
+        private enum Fields: String, CodingKey {
+                case name
+                case city
+        }
+
+        @Test
+        func testProducesAirtableFriendlyStrings() {
+                let equals = AirtableFormulaBuilder.equals("O'Hara", in: Fields.name)
+                let notEquals = AirtableFormulaBuilder.notEquals("O'Hara", in: Fields.name)
+                let isEmpty = AirtableFormulaBuilder.isEmpty(Fields.city)
+                let recordID = AirtableFormulaBuilder.id("recABC123")
+
+                #expect(equals.description == "{name} = 'O\\'Hara'")
+                #expect(notEquals.description == "{name} != 'O\\'Hara'")
+                #expect(isEmpty.description == "{city} = BLANK()")
+                #expect(recordID.description == "RECORD_ID() = 'recABC123'")
+        }
+
+        @Test
+        func testCombinesFormulasWithAndOrNot() {
+                let emptyCheck = AirtableFormulaBuilder.isEmpty(Fields.city)
+                let nameEquals = AirtableFormulaBuilder.equals("Jean", in: Fields.name)
+                let idMatches = AirtableFormulaBuilder.ids(["rec1", "rec2"])
+
+                let combined = AirtableFormulaBuilder.and(
+                        nameEquals,
+                        emptyCheck.not,
+                        idMatches
+                )
+
+                #expect(combined.description == "AND({name} = 'Jean', NOT({city} = BLANK()), OR(RECORD_ID() = 'rec1', RECORD_ID() = 'rec2'))")
+        }
+
+        @Test
+        func testEscapesApostrophesInInterpolation() {
+                enum Borough: String { case queens = "Queen's" }
+
+                let rawEscaped: String = "\(e: "O'Hara")"
+                let representableEscaped: String = "\(e: Borough.queens)"
+                let formula = "Filter: \(AirtableFormulaBuilder.equals("O'Hara", in: Fields.name))"
+
+                #expect(rawEscaped == "O\\'Hara")
+                #expect(representableEscaped == "Queen\\'s")
+                #expect(formula.contains("{name} = 'O\\'Hara'"))
+        }
+}
+
+#endif


### PR DESCRIPTION
## Summary
- add AirtableFormulaBuilder test suite covering formula composition and apostrophe escaping
- convert TESTS_COVERAGE document to checklist format with statuses and descriptions

## Testing
- swift test *(fails: SwiftUI module unavailable in this environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69338158ac0c832e96a6891dc53bb214)