### PR TITLE
Enhance `QizhKit` with an option to disable HDR support, shape utilities, and collection extensions

### DIFF
--- a/.github/agents/qizh.agent.md
+++ b/.github/agents/qizh.agent.md
@@ -48,3 +48,8 @@ author_name: Serhii
 - Run all tests to make sure none of them fails
 - Generate and post a report
 - Update the PR description with the results
+
+## For Small Changes (≤42 lines)
+- **Apply directly as a commit** instead of creating a PR sibling
+- Small changes include minor fixes, typo corrections, documentation updates, and simple refactoring
+- If the change grows beyond 42 lines during implementation, consider creating a proper PR instead

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,6 +106,11 @@ The following dependencies are used (package name → product name):
 
 ## What You Should Do
 
+### For Small Changes (≤42 lines)
+- **Apply directly as a commit** instead of creating a PR sibling
+- Small changes include minor fixes, typo corrections, documentation updates, and simple refactoring
+- If the change grows beyond 42 lines during implementation, consider creating a proper PR instead
+
 ### For Code Changes
 1. **Review existing code patterns** before making changes
 2. **Write tests** for new functionality
@@ -240,6 +245,6 @@ The repository has a custom agent configured in `.github/agents/qizh.agent.md` w
 
 ---
 
-**Last Updated**: 2025-12-01
+**Last Updated**: 2025-12-05
 **Swift Version**: 6.1+
 **Minimum Platforms**: iOS 17, macOS 14, macCatalyst 17

--- a/.swiftpm/xcode/xcshareddata/xcschemes/QizhKit.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/QizhKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2610"
+   LastUpgradeVersion = "2620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ab52bcb73cbd8f4893c8d2d5472db18a27f79d4a31f6b6ed5017f995a88bb497",
+  "originHash" : "f54d46681913b81a2dd43f13358d3ccb03b5e358fc26544555f60a4133f2e720",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/qizh/QizhMacroKit",
       "state" : {
-        "revision" : "eeeb14a1aaa390fdfd92f16c7c42124def2d3a92",
-        "version" : "1.1.14"
+        "revision" : "3babd3d59542b4fe9457faf3f83f096868ec2704",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -70,7 +70,7 @@ let package = Package(
 		.package(url: "https://github.com/apple/swift-collections", from: "1.3.0"),
 		
 		/// Macros
-		.package(url: "https://github.com/qizh/QizhMacroKit", from: "1.1.14"),
+		.package(url: "https://github.com/qizh/QizhMacroKit", from: "1.1.15"),
 	],
 	targets: [
 		.target(

--- a/Package.swift
+++ b/Package.swift
@@ -126,7 +126,7 @@ let package = Package(
 		.package(url: "https://github.com/apple/swift-collections", from: "1.3.0"),
 		
 		/// Macros
-		.package(url: "https://github.com/qizh/QizhMacroKit", from: "1.1.16"),
+		.package(url: "https://github.com/qizh/QizhMacroKit", from: "1.1.18"),
 	],
 	targets: [
 		.target(
@@ -149,7 +149,7 @@ let package = Package(
 				
 				/// Macros
 				.product(name: "QizhMacroKit", package: "QizhMacroKit"),
-				.product(name: "QizhMacroKitClient", package: "QizhMacroKit"),
+				// .product(name: "QizhMacroKitClient", package: "QizhMacroKit"),
 			],
 			exclude: [
 				"Off/",

--- a/Package.swift
+++ b/Package.swift
@@ -4,13 +4,14 @@
 import PackageDescription
 import Foundation // ← for ProcessInfo
 
-/// Decide if HDR APIs should be enabled for QizhKit.
+/// Decide if HDR APIs should be enabled for `QizhKit`.
 /// On your Mac, set `QIZHKIT_ENABLE_HDR=1` in the environment when building.
 /// - Experiment:
-/// ```zsh
-/// launchctl setenv QIZHKIT_ENABLE_HDR 1
-/// launchctl getenv QIZHKIT_ENABLE_HDR # should output 1
-/// ```
+///   ```zsh
+///   launchctl setenv QIZHKIT_ENABLE_HDR 1
+///   launchctl getenv QIZHKIT_ENABLE_HDR
+///   # should output 1
+///   ```
 let isHDREnabled: Bool =
 	if let value = ProcessInfo.processInfo.environment["QIZHKIT_ENABLE_HDR"] {
 		value == "1" || value.lowercased() == "true"
@@ -70,7 +71,7 @@ let package = Package(
 		.package(url: "https://github.com/apple/swift-collections", from: "1.3.0"),
 		
 		/// Macros
-		.package(url: "https://github.com/qizh/QizhMacroKit", from: "1.1.15"),
+		.package(url: "https://github.com/qizh/QizhMacroKit", from: "1.1.16"),
 	],
 	targets: [
 		.target(

--- a/Package.swift
+++ b/Package.swift
@@ -126,7 +126,7 @@ let package = Package(
 		.package(url: "https://github.com/apple/swift-collections", from: "1.3.0"),
 		
 		/// Macros
-		.package(url: "https://github.com/qizh/QizhMacroKit", from: "1.1.18"),
+		.package(url: "https://github.com/qizh/QizhMacroKit", from: "1.3.0"),
 	],
 	targets: [
 		.target(

--- a/Package.swift
+++ b/Package.swift
@@ -126,7 +126,7 @@ let package = Package(
 		.package(url: "https://github.com/apple/swift-collections", from: "1.3.0"),
 		
 		/// Macros
-		.package(url: "https://github.com/qizh/QizhMacroKit", exact: "1.5.0"),
+		.package(url: "https://github.com/qizh/QizhMacroKit", from: "1.4.2"),
 	],
 	targets: [
 		.target(

--- a/Package.swift
+++ b/Package.swift
@@ -126,7 +126,7 @@ let package = Package(
 		.package(url: "https://github.com/apple/swift-collections", from: "1.3.0"),
 		
 		/// Macros
-		.package(url: "https://github.com/qizh/QizhMacroKit", from: "1.3.0"),
+		.package(url: "https://github.com/qizh/QizhMacroKit", exact: "1.5.0"),
 	],
 	targets: [
 		.target(

--- a/Sources/QizhKit/Components/Airtable/AirtableModel.swift
+++ b/Sources/QizhKit/Components/Airtable/AirtableModel.swift
@@ -134,7 +134,7 @@ public protocol RailsModel: KeyedEmptyableBackendModel {
 /// In case the model is a wrapper or a submit model
 /// and there's no id in it
 extension RailsModel {
-	public var id: UInt8 { 0 }
+	public var id: UInt { 0 }
 }
 
 public struct RailsResponse <Item>: Codable, Sendable

--- a/Sources/QizhKit/Extensions/Bundle+/Bundle+forLocale.swift
+++ b/Sources/QizhKit/Extensions/Bundle+/Bundle+forLocale.swift
@@ -1,0 +1,87 @@
+//
+//  Bundle+forLocale.swift
+//  QizhKit
+//
+//  Created by Serhii Shevchenko on 27.11.2023.
+//  Copyright © 2023 Bespokely. All rights reserved.
+//
+
+public import Foundation
+
+extension Bundle {
+	/// Returns a bundle that best matches the given `Locale`, if available, falling back
+	/// to broader language resources or the receiver.
+	///
+	/// ## Why this exists
+	/// This helper is useful when you need to resolve localized resources for a specific
+	/// locale independently of the app/system language — for example, to preview a locale,
+	/// render server-provided content in a chosen language, or test translations. By
+	/// returning a locale-specific bundle, you can pass it to APIs like
+	/// `String(localized:bundle:)`, `Image.init(_:bundle:)`, or manual resource loading.
+	///
+	/// ## Strings Catalogs (`.xcstrings`)
+	/// If your project uses Strings Catalogs, you usually do NOT need to manually switch
+	/// bundles per locale for ordinary app localization — the system resolves the
+	/// appropriate localization based on the user's settings. However, this method remains
+	/// relevant when you intentionally want per-locale lookups regardless of the current
+	/// system language (e.g., in settings screens or debug tooling). Strings Catalogs still
+	/// compile into `.lproj` resources at build time, so resolving a locale-specific bundle
+	/// via `.lproj` remains valid.
+	///
+	/// ## Resolution strategy
+	/// The method attempts the following in order:
+	/// 1. Exact identifier match (e.g., `"en-US"`, `"zh-Hant-TW"`) using the locale's
+	///    canonical identifier.
+	/// 2. Language-script-region fallbacks by progressively trimming components (e.g.,
+	///    `"zh-Hant-TW"` → `"zh-Hant"` → `"zh"`).
+	/// 3. Language-only code using `LanguageCode` (e.g., `"en"`).
+	/// 4. Returns `self` if nothing matches.
+	///
+	/// - Note:
+	///   - This relies on `.lproj` directories being present in the bundle.
+	///   - Prefer one of the following methods with the returned bundle
+	///     when you need explicit per-locale strings:
+	///     - `String(localized:keyAndValue:bundle:table:)`
+	///     - `String(localized:bundle:)`
+	///     For normal app UI, rely on the system's selected language and don't call this.
+	///   - Consider `Bundle.preferredLocalizations` and `Bundle.localizations` if you need
+	///     to inspect availability.
+	/// - Parameter locale: The target locale for resource resolution.
+	/// - Returns: A `Bundle` matching the locale if possible, otherwise `self`.
+	public func forLocale(_ locale: Locale) -> Bundle {
+		/// Build a list of candidate identifiers to try, from most specific to least.
+		/// Use canonical identifiers to align with `.lproj` naming conventions.
+		var candidates: [String] = []
+		let canonical = locale.identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+			.replacingOccurrences(of: "_", with: "-")
+		if !canonical.isEmpty { candidates.append(canonical) }
+
+		/// If identifier contains hyphen-separated parts, progressively trim components.
+		/// ## For example
+		/// ```swift
+		/// "zh-Hant-TW" → "zh-Hant" → "zh"
+		/// ```
+		let parts = canonical.split(separator: .minus)
+		if parts.count > 1 {
+			for i in stride(from: parts.count - 1, through: 1, by: -1) {
+				let trimmed = parts.prefix(i).joined(separator: "-")
+				if !candidates.contains(trimmed) { candidates.append(trimmed) }
+			}
+		}
+
+		// Add language-only fallback from Locale.Language if available.
+		if let lang = locale.language.languageCode?.identifier, !lang.isEmpty, !candidates.contains(lang) {
+			candidates.append(lang)
+		}
+
+		// Try to resolve an `.lproj` bundle for the first matching candidate.
+		for id in candidates {
+			if let path = self.path(forResource: id, ofType: "lproj"),
+			   let b = Bundle(path: path) {
+				return b
+			}
+		}
+
+		return self
+	}
+}

--- a/Sources/QizhKit/Extensions/Collection+/Collection+cast.swift
+++ b/Sources/QizhKit/Extensions/Collection+/Collection+cast.swift
@@ -8,30 +8,108 @@
 
 import Foundation
 
-extension ArraySlice {
-	@inlinable public func asArray() -> [Element] { Array(self) }
-}
-
 extension Slice {
+	/// Converts this `Slice` into a standalone `Array`.
+	///
+	/// Use this to materialize a slice into a concrete `Array` when you need
+	/// random-access semantics with zero-based indexing, to pass the elements
+	/// to APIs that specifically require an `Array`, or to explicitly detach
+	/// the elements from their base collection.
+	/// - Invariant: The resulting array preserves the order and values of the
+	///   elements in the slice. Indices are normalized to start at zero and
+	///   the result is fully detached from the base collection.
+	/// - Returns: A new `Array` containing the elements of the slice, in the same order.
+	/// - Important: This always allocates new storage and copies elements. Mutating
+	///   the returned array does not affect the original slice or its base collection,
+	///   and vice versa.
+	/// - Complexity: `O(n)`, where n is the number of elements in the slice.
 	@inlinable public func asArray() -> [Base.Element] { Array(self) }
 }
 
-extension Collection {
+extension Sequence {
+	/// Converts the receiver into a standalone `Array`.
+	///
+	/// Use this to materialize a sequence, collection, or slice into a concrete `Array`,
+	/// for example when you need random access semantics, zero-based indexing, or to pass
+	/// the values to APIs that specifically require an `Array`.
+	/// - Invariant: The resulting array preserves the order of elements and contains
+	///   the same elements as the receiver. For slices, this also normalizes indices
+	///   to start at zero and detaches the result from the base collection.
+	/// - Returns: A new `Array` containing the elements of the receiver, in the same order.
+	/// - Important: This always allocates new storage and copies elements. Mutating the
+	///   returned array does not affect the original sequence or collection, and vice versa.
+	/// - Complexity: `O(n)`, where n is the number of elements in the receiver.
 	@inlinable public func asArray() -> [Element] { Array(self) }
 }
 
-extension RangeReplaceableCollection
-	where Self == Self.SubSequence,
-		  Self: Sendable
-{
-	@inlinable public func asCollection <C> () -> C
-		where C: RangeReplaceableCollection,
-			  C.Element == Element
-	{
+extension RangeReplaceableCollection where Self == Self.SubSequence,
+										   Self: Sendable {
+	/// Converts this range-replaceable, self-slicing collection into another
+	/// `RangeReplaceableCollection` of the same element type.
+	///
+	/// Use this to materialize a slice-like collection (for example, `ArraySlice`)
+	/// or any collection whose `SubSequence == Self` into a concrete destination
+	/// collection type (e.g. `Array`, `ContiguousArray`, `Deque`), while preserving
+	/// element order and values. This is especially useful when you need to:
+	/// - Detach elements from their base collection
+	/// - Satisfy APIs that require a specific collection type
+	/// - Normalize indices (e.g. moving from slice indexing to zero-based indexing
+	///   in the destination)
+	/// - Invariant: The resulting collection contains exactly the same elements
+	///   in the same order as the receiver. The result is fully detached from any base
+	///   collection the receiver may reference (e.g. for slices).
+	/// - Precondition:
+	///   ## Generic Parameter `C`
+	///   The destination collection type. Must conform to `RangeReplaceableCollection`
+	///   and have the same `Element` as `Self`.
+	/// - Returns: A new collection of type `C` containing the elements of `self`.
+	/// - Important: This operation allocates new storage and copies elements.
+	///   Mutating the returned collection will not affect the original collection
+	///   (or its base), and vice versa.
+	/// - Complexity: `O(n)`, where n is the number of elements in `self`.
+	/// ## Example
+	/// ```swift
+	/// let slice: ArraySlice<Int> = [10, 20, 30][1...] // [20, 30]
+	/// let array: [Int] = slice.asCollection()         // [20, 30]
+	/// let contiguous: ContiguousArray<Int> =
+	/// 	slice.asCollection()                        // [20, 30]
+	/// ```
+	@inlinable public func asCollection<C>() -> C where C: RangeReplaceableCollection,
+														C.Element == Element {
 		C(self)
 	}
 }
 
-extension Sequence where Element: Hashable, Self: Sendable {
+extension Sequence where Element: Hashable {
+	/// Converts the sequence into a `Set` of its elements, removing any duplicates.
+	/// 
+	/// ## Use this when you need to
+	/// - Eliminate duplicate elements from a sequence
+	/// - Perform fast membership tests (`contains`) or set operations
+	///   (`union`, `intersection`)
+	/// - Materialize a `Sequence` into a hash-based collection
+	/// - Invariant:
+	///   - The resulting set contains each distinct element from the sequence at most once.
+	///   - Element order is not preserved; `Set` is an unordered collection.
+	///   - Requires `Element` to conform to `Hashable`.
+	/// - Returns: A new `Set` containing the unique elements of the sequence.
+	/// - Important:
+	///   - This always allocates new storage and copies elements.
+	///   - If `self` is already a `Set`, this creates a (copy-on-write) copy.
+	///   - The entire sequence is iterated; for single-pass or infinite sequences, this will
+	///     consume the sequence (and never complete for infinite ones).
+	/// - Complexity: Average-case `O(n)`, where `n` is the number of elements in the
+	///   sequence; worst-case can be higher if many elements collide in their hash values.
+	/// ## Example
+	/// ```swift
+	/// let numbers = [1, 2, 2, 3, 3, 3]
+	/// let unique = numbers.asSet()
+	/// // Set([1, 2, 3])
+	///
+	/// let characters = "mississippi".asSet()
+	/// // Set(["m", "i", "s", "p"])
+	///
+	/// #expect(unique.contains(2))
+	/// ```
 	@inlinable public func asSet() -> Set<Element> { Set(self) }
 }

--- a/Sources/QizhKit/Extensions/Color+/Color+values.swift
+++ b/Sources/QizhKit/Extensions/Color+/Color+values.swift
@@ -259,6 +259,13 @@ extension AnyShapeStyle {
 	public static let tertiary: AnyShapeStyle = .init(HierarchicalShapeStyle.tertiary)
 	public static let quaternary: AnyShapeStyle = .init(HierarchicalShapeStyle.quaternary)
 	public static let quinary: AnyShapeStyle = .init(HierarchicalShapeStyle.quinary)
+	
+	public static let regularMaterial: AnyShapeStyle = .init(Material.regular)
+	public static let thickMaterial: AnyShapeStyle = .init(Material.thick)
+	public static let thinMaterial: AnyShapeStyle = .init(Material.thin)
+	public static let ultraThinMaterial: AnyShapeStyle = .init(Material.ultraThin)
+	public static let ultraThickMaterial: AnyShapeStyle = .init(Material.ultraThick)
+	public static let barMaterial: AnyShapeStyle = .init(Material.bar)
 }
 
 extension ShapeStyle {

--- a/Sources/QizhKit/Extensions/DynamicType+/DynamicTypeSize+interpolate.swift
+++ b/Sources/QizhKit/Extensions/DynamicType+/DynamicTypeSize+interpolate.swift
@@ -28,10 +28,47 @@ extension DynamicTypeSize {
 }
 
 extension RangeExpression where Self == ClosedRange<DynamicTypeSize> {
+	/// This range spans from `.xSmall` through `.xxxLarge`, covering the regular
+	/// content size categories and excluding the accessibility sizes
+	///
+	/// Use this when you want to:
+	/// - Iterate over or filter the regular Dynamic Type cases.
+	/// - Compute progress or interpolate values across standard sizes
+	///   (e.g., for layout or typography scaling), in combination with helpers
+	///   like `DynamicTypeSize.progress(in:)` or `ClosedRange.interpolated(for:from:)`.
+	///
+	/// - Note: The following accessibility sizes are excluded.
+	///   ```swift
+	///   .accessibility1 ... .accessibility5
+	///   ```
+	///
+	/// - SeeAlso:
+	///   - `fullRange` for a range that includes accessibility sizes.
+	///   - `DynamicTypeSize.allRegularCases` for an array of all regular cases.
 	public static var regularRange: ClosedRange<DynamicTypeSize> {
 		.xSmall ... .xxxLarge
 	}
 	
+	/// A range that spans from `.xSmall` through `.accessibility5`, covering
+	/// every `DynamicTypeSize` case, including the accessibility sizes.
+	/// 
+	/// Use this when you want to:
+	/// - Iterate over or filter all Dynamic Type cases, including accessibility.
+	/// - Compute progress or interpolate values across the entire spectrum,
+	///   in combination with helpers like `DynamicTypeSize.progress(in:)`
+	///   or `ClosedRange.interpolated(for:from:)`.
+	/// - Ensure UI scales appropriately even for the largest accessibility sizes.
+	/// 
+	/// - Note:
+	///   ```swift
+	///   .accessibility1 ... .accessibility5
+	///   ```
+	///   These accessibility sizes represent significantly larger text
+	///   and may require layout considerations.
+	///
+	/// - SeeAlso:
+	///   - `regularRange` for a range that excludes accessibility sizes.
+	///   - `DynamicTypeSize.allCases` for an array of all cases.
 	public static var fullRange: ClosedRange<DynamicTypeSize> {
 		.xSmall ... .accessibility5
 	}

--- a/Sources/QizhKit/Extensions/Shape+/Shape+sugar.swift
+++ b/Sources/QizhKit/Extensions/Shape+/Shape+sugar.swift
@@ -41,6 +41,30 @@ extension Shape {
 }
 
 extension InsettableShape {
+	/// Fills the shape with the specified style and draws a stroked border using a line
+	/// width.
+	///
+	/// This convenience modifier first renders the shape’s interior using the provided
+	/// `fillStyle`, then overlays a stroke along the shape’s path using `strokeColor`
+	/// and `lineWidth`. The fill is placed behind the stroke to ensure a crisp outline
+	/// without obscuring the fill.
+	/// - Parameters:
+	///   - fillStyle: The style used to fill the interior of the shape. You can pass any
+	///     `ShapeStyle`, such as `Color`, `Gradient`, `.tint`, or `.foregroundStyle`.
+	///   - strokeColor: The style used to draw the border of the shape. Accepts any
+	///     `ShapeStyle`, allowing solid colors, materials, or gradients.
+	///   - lineWidth: The thickness of the border line, in points. Defaults to `1.0`.
+	/// - Returns: A view that first fills the shape with `fillStyle` and then draws a
+	///   stroked outline using `strokeColor` and `lineWidth`.
+	/// This variant uses `stroke(_:lineWidth:)`, which centers the stroke on the
+	/// shape’s path. If you need the stroke to be drawn strictly inside or outside
+	/// the shape’s bounds, consider using an `InsettableShape` and its
+	/// `strokeBorder`-based variant instead.
+	/// - SeeAlso:
+	///   - `Shape.stroke(_:lineWidth:)`
+	///   - `Shape.fill(_:style:)`
+	///   - `InsettableShape.fill(_:strokeBorder:lineWidth:)`
+	///   - `InsettableShape.strokeBorder(_:lineWidth:)`
 	public func fill <Fill: ShapeStyle, Stroke: ShapeStyle> (
 		_ fillStyle: Fill,
 		strokeBorder strokeColor: Stroke,
@@ -51,6 +75,32 @@ extension InsettableShape {
 			.background(self.fill(fillStyle))
 	}
 	
+	/// Fills the shape with the specified style and draws a stroked border using a custom
+	/// stroke style.
+	///
+	/// This modifier first renders the shape’s interior using `fillStyle`, then overlays
+	/// a stroked outline using `strokeColor` and the provided `strokeStyle`.
+	/// It is a convenience that mirrors SwiftUI’s `fill(_:style:)` + `stroke(_:style:)`,
+	/// ensuring the fill remains visually beneath the stroke.
+	/// - Parameters:
+	///   - fillStyle: The style used to fill the interior of the shape. You can pass any
+	///     `ShapeStyle`, such as `Color`, `Gradient`, `.tint`, or `.foregroundStyle`.
+	///   - strokeColor: The style used to draw the border of the shape. Accepts any
+	///     `ShapeStyle`, allowing solid colors, materials, or gradients.
+	///   - strokeStyle: A `StrokeStyle` that configures how the border is drawn, including
+	///     line width, line cap, line join, miter limit, dash pattern, and dash phase.
+	/// - Returns: A view that first fills the shape with `fillStyle` and then draws a
+	///   stroked outline using `strokeColor` and `strokeStyle`.
+	/// Use this when you want a filled shape with a customized outline in a single call.
+	/// The stroke is drawn over the fill, maintaining a clear border while preserving
+	/// the fill’s appearance. If you need the stroke to be inset relative to the shape’s
+	/// path, consider using an `InsettableShape` and its `strokeBorder`-based variants.
+	/// - SeeAlso:
+	///   - `Shape.fill(_:strokeBorder:lineWidth:)`
+	///   - `Shape.stroke(_:lineWidth:)`
+	///   - `Shape.stroke(_:style:)`
+	///   - `InsettableShape.strokeBorder(_:lineWidth:)`
+	///   - `InsettableShape.stroke(border:thickness:with:opacity:smooth:)`
 	public func fill <Fill: ShapeStyle, Stroke: ShapeStyle> (
 		_ fillStyle: Fill,
 		strokeBorder strokeColor: Stroke,
@@ -59,6 +109,48 @@ extension InsettableShape {
 		self
 			.strokeBorder(strokeColor, style: strokeStyle)
 			.background(self.fill(fillStyle))
+	}
+	
+	/// Strokes the outline of the shape with configurable border positioning, thickness,
+	/// style, and antialiasing.
+	///
+	/// This method draws the stroke along the shape’s path by first insetting the shape
+	/// according to the desired border position (inside, center, or outside) for the
+	/// given thickness, then applying a `strokeBorder` with the specified style. It is
+	/// especially useful when you want precise control over whether the stroke appears
+	/// inside, centered on, or outside the original shape boundary.
+	/// - Parameters:
+	///   - position: The relative placement of the stroke in relation to the shape’s path.
+	///     Use `.inside`, `.center`, or `.outside`. The default is `.default`,
+	///     which is `.center`.
+	///   - thickness: The width of the stroke in points. The default is `1.0`.
+	///   - style: The `ShapeStyle` used to render the stroke
+	///     (for example, `.tint`, `Color`, `LinearGradient`).
+	///   - opacity: A value between `0.0` (fully transparent) and `1.0` (fully opaque)
+	///     applied to the stroke style. The default is `1.0`.
+	///   - antialiased: A `Boolean` value that indicates whether SwiftUI should smooth
+	///     edges when drawing the stroke. The default is `true`.
+	/// - Returns:
+	///   A view that draws the shape’s stroke according to the provided parameters.
+	/// - Requires:
+	///   This modifier is available on types conforming to `InsettableShape`, enabling
+	///   accurate border placement by insetting the shape before stroking. The inset
+	///   amount is computed from the `position` and `thickness`, preventing visual growth
+	///   or shrinkage of the shape when placing the stroke strictly inside or outside.
+	/// - SeeAlso:
+	///   - `strokeBorder(_:lineWidth:antialiased:)`
+	///   - `InsettableShape`
+	///   - ``LinePosition``
+	public func stroke(
+		border position: LinePosition = .default,
+		thickness: CGFloat = 1.0,
+		with style: some ShapeStyle,
+		opacity: Double = 1.0,
+		smooth antialiased: Bool = true
+	) -> some View {
+		self.inset(by: position.inset(for: thickness))
+			.strokeBorder(style.opacity(opacity), lineWidth: thickness, antialiased: antialiased)
+			
 	}
 }
 
@@ -94,3 +186,4 @@ public typealias AnimatableCGFloatPair = AnimatablePair<CGFloat, CGFloat>
 /// Useful for animating rectangles (origin + size), edge insets, or other
 /// four-component geometric data in SwiftUI.
 public typealias AnimatableCGFloatQuartet = AnimatableQuartet<CGFloat>
+

--- a/Sources/QizhKit/Extensions/String+/String+constants.swift
+++ b/Sources/QizhKit/Extensions/String+/String+constants.swift
@@ -20,9 +20,24 @@ public extension Character {
 	static let quotChar: Character         			= "\""
 	/** | */ static let lineChar: Character 		= "|"
 	static let apostropheChar: Character   			= "'"
-	
-	static let plusChar: Character         			= "+"
+	/// `+`
+	/// - Returns: Unicode "PLUS SIGN": `U+002B`
+	/// ```swift
+	/// Character("+")
+	/// ```
+	static let plusChar: Character = "+"
+	/// `-`
+	/// - Returns: Unicode "HYPHEN-MINUS": `U+002D`
+	/// ```swift
+	/// Character("-")
+	/// ```
 	static let minusChar: Character        			= "-"
+	/// `-`
+	/// - Returns: Unicode "HYPHEN-MINUS": `U+002D`
+	/// ```swift
+	/// Character("-")
+	/// ```
+	static let hyphenChar: Character        		= "-"
 	static let multiplyChar: Character     			= "✕"
 	static let xMarkChar: Character        			= "✕"
 	static let checkMarkChar: Character        		= "✔︎"

--- a/Sources/QizhKit/Extensions/View+/View+apply.swift
+++ b/Sources/QizhKit/Extensions/View+/View+apply.swift
@@ -23,11 +23,74 @@ extension View {
 // MARK: > Variadic Generics
 
 extension View {
+	/// Applies a transformation to the current view, returning the transformed result.
+	/// 
+	/// Use this helper to make view modifier chains more expressive by
+	/// grouping multiple modifiers or conditional logic inside a single closure.
+	/// The closure receives `self` (the current view) and must return a new view.
+	/// ## Example
+	/// ```swift
+	/// VStack {
+	///     Text("Title")
+	/// }
+	/// .apply { view in
+	///     view
+	///         .padding()
+	///         .background(.blue.opacity(0.1))
+	/// }
+	/// ```
+	/// - Parameter transform: A closure that takes the current view as input and
+	///   returns a transformed view. Use `@ViewBuilder` to compose multiple view
+	///   modifiers and layout containers within the closure.
+	/// - Returns: The result of applying `transform` to the current view.
 	@inlinable public func apply <V: View, each P> (
 		@ViewBuilder _ transform: (Self, repeat each P) -> V,
 		_ parameters: repeat each P
 	) -> some View {
 		transform(self, repeat each parameters)
+	}
+	
+	/// Conditionally applies a transformation to the current view,
+	/// passing additional parameters.
+	///
+	/// Use this overload when you want to modify a view only if a Boolean condition
+	/// is `true`, while also supplying one or more extra parameters to the transformation.
+	/// The original view is returned unchanged when the condition is `false`.
+	/// ## Example
+	/// ```swift
+	/// VStack {
+	///     Text("Hello")
+	/// }
+	/// .apply(
+	/// 	when: isHighlighted, Color.yellow.opacity(0.2), 12
+	/// ) { view, color, radius in
+	///     view
+	///         .padding()
+	///         .background(color)
+	///         .clipShape(RoundedRectangle(cornerRadius: radius))
+	/// }
+	/// ```
+	/// - Parameters:
+	///   - condition: A Boolean value that determines
+	///     whether the transformation is applied.
+	///   - transform: A closure that takes the current view (`self`)
+	///     followed by the supplied parameters and returns a transformed view.
+	///     Use `@ViewBuilder` to compose multiple modifiers and layout containers.
+	///   - parameters: One or more additional values to pass through
+	///     to the `transform` closure.
+	/// - Returns: The transformed view when `condition` is `true`;
+	///   otherwise, the original view.
+	@ViewBuilder
+	public func apply<V: View, each P> (
+		when condition: Bool,
+		@ViewBuilder _ transform: (Self, repeat each P) -> V,
+		_ parameters: repeat each P
+	) -> some View {
+		if condition {
+			transform(self, repeat each parameters)
+		} else {
+			self
+		}
 	}
 }
 
@@ -106,6 +169,23 @@ extension View {
 		}
 	}
 	
+	/// Conditionally transforms the current view when both optional values are non-`nil`.
+	///
+	/// Use this overload to apply a transformation that depends on two optional inputs.
+	/// If both `optional1` and `optional2` contain values, the `transform` closure is
+	/// invoked with `self` and the unwrapped values, and its result is returned.
+	/// If either optional is `nil`, the original view (`self`) is returned unchanged.
+	/// - Parameters:
+	///   - optional1: The first optional value to unwrap.
+	///   - optional2: The second optional value to unwrap.
+	///   - transform: A closure that takes the current view and the two unwrapped values,
+	///     returning a new view. The closure is only executed when both optionals are
+	///     non-nil.
+	/// - Returns: The transformed view when both optionals are non-nil;
+	///   otherwise, the original view.
+	/// - Note: Prefer this method when you need both values to proceed;
+	///   if you also need a fallback when either value is missing,
+	///   use the overload that includes an `else` fallback closure.
 	@ViewBuilder
 	public func apply <T1, T2> (
 		when optional1: T1?,

--- a/Sources/QizhKit/Extensions/View+/View+roundedBorder.swift
+++ b/Sources/QizhKit/Extensions/View+/View+roundedBorder.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import QizhMacroKit
 
 public extension View {
 	#if canImport(UIKit)
@@ -170,18 +171,68 @@ public extension View {
 
 // MARK: Line Position
 
-/// Enum for calculating border line insets
-public enum LinePosition: EasyCaseComparable {
+/// Represents where a stroked border line should be placed relative to the
+/// shape’s actual boundary when drawing borders (strokes).
+///
+/// Use this enum to control whether the stroke is centered on the boundary,
+/// drawn entirely inside, or drawn entirely outside. This is especially useful
+/// when you need pixel-perfect alignment or want to avoid clipping caused by
+/// stroke thickness.
+/// ## Cases
+/// - ``center``\
+///   The border line is centered on the shape’s boundary (default).
+///   Half of the stroke lies inside and half outside.
+/// - ``inner``\
+///   The border line is inset so it lies fully inside the shape’s
+///   boundary. Useful to prevent the stroke from being clipped by parent
+///   views or to ensure the shape’s outer size remains unchanged.
+/// - ``outer``\
+///   The border line is outset so it lies fully outside the shape’s
+///   boundary. Useful to preserve the interior content area exactly as sized.
+/// ## Conformance
+/// - `Hashable`
+/// - `Sendable`
+/// - `CaseIterable`
+/// ## Utilities
+/// - ``inset(for:)``\
+///   Computes the inset amount for a given stroke weight:
+///   - ``center`` returns
+///     ```swift
+///     0
+///     ```
+///   - ``inner`` returns
+///     ```swift
+///     weight / 2
+///     ```
+///   - ``outer`` returns
+///     ```swift
+///     -weight / 2
+///     ```
+/// ## Typical usage
+/// - When overlaying a shape with `.stroke`/`.strokeBorder`, pass
+///   `position.inset(for: weight)` to `.inset(by:)` so the stroke aligns
+///   as desired without changing the view’s visual layout unexpectedly.
+@IsCase
+public enum LinePosition: Hashable, Sendable, CaseIterable, DefaultCaseFirst {
 	case center
 	case inner
 	case outer
 	
 	/// Calculate the border line inset
 	/// - Parameter weight: Border weight line to be insetted
-	/// - Returns:
-	///   - Zero for ``center`` case,
-	///   - `weight` half for ``inner``
-	///   - Negated `weight` half for ``outer``
+	/// - Returns: Computes the inset amount for a given stroke `weight` and returns:
+	///   - ``center``
+	///     ```swift
+	///     0
+	///     ```
+	///   - ``inner``
+	///     ```swift
+	///     weight / 2
+	///     ```
+	///   - ``outer``
+	///     ```swift
+	///     -weight / 2
+	///     ```
 	public func inset(for weight: CGFloat) -> CGFloat {
 		switch self {
 		case .center: .zero

--- a/Sources/QizhKit/Extensions/View+/View+roundedBorder.swift
+++ b/Sources/QizhKit/Extensions/View+/View+roundedBorder.swift
@@ -178,12 +178,15 @@ public enum LinePosition: EasyCaseComparable {
 	
 	/// Calculate the border line inset
 	/// - Parameter weight: Border weight line to be insetted
-	/// - Returns: Zero for ``center`` case, `weight` half for ``inner``, and minus `weight` half for ``outer``
+	/// - Returns:
+	///   - Zero for ``center`` case,
+	///   - `weight` half for ``inner``
+	///   - Negated `weight` half for ``outer``
 	public func inset(for weight: CGFloat) -> CGFloat {
 		switch self {
-		case .center: return .zero
-		case .inner:  return  weight.half
-		case .outer:  return -weight.half
+		case .center: .zero
+		case .inner:   weight.half
+		case .outer:  -weight.half
 		}
 	}
 }

--- a/Sources/QizhKit/QizhKit.swift
+++ b/Sources/QizhKit/QizhKit.swift
@@ -1,0 +1,20 @@
+//
+//  QizhKit.swift
+//  QizhKit
+//
+//  Created by Serhii Shevchenko on 11.12.2025.
+//
+
+import Foundation
+
+#if RESOLVED_HDR_AVAILABLE
+let qh2 = true
+#else
+let qh2 = false
+#endif
+
+// MARK: Bundle
+
+extension Bundle {
+	public static let qizhKit: Bundle = .module
+}

--- a/Sources/QizhKit/Structures/Codable/AutoTypeCodable.swift
+++ b/Sources/QizhKit/Structures/Codable/AutoTypeCodable.swift
@@ -8,38 +8,96 @@
 
 import Foundation
 
+/// A property wrapper that decodes a value of type `T` from a variety of `JSON`
+/// representations and encodes it back as `T`.
+///
+/// Use this when the upstream payload is inconsistent. For example, when numbers sometimes
+/// arrive as strings or booleans are represented as `0`/`1`.
+/// - Requires:
+///   - `T` must conform to `LosslessStringConvertible` and `Codable`.
+/// ## Decoding:
+/// - First attempts to decode `T` directly.
+/// - If that `fails`, it tries common primitives
+///   - `String`
+///   - `Bool` (including `NSNumber` `0`/`1`)
+///   - integer types
+///   - floating‑point types
+///   - `Decimal`
+///   - `Date`
+/// - The first successfully decoded value is then converted to `T`
+///   via its lossless string initializer.
+/// ## Encoding:
+/// - Converts the wrapped value to a `String` and re‑initializes `T` from that string
+///   to preserve the canonical representation before encoding.
+/// ## Usage:
+/// ```swift
+/// struct Payload: Codable {
+///     /// Accepts numbers or strings like "42" and encodes as an `Int`.
+///     @AutoTypeCodable var intValue: Int
+///
+///     /// Accepts strings like "3.14" or numeric doubles.
+///     @AutoTypeCodable var doubleValue: Double
+///
+///     /// Accepts string or numeric representations of decimals.
+///     @AutoTypeCodable var price: Decimal
+///
+///     /// Accepts a date string in format "dd.MM.yyyy HH:mm" or `null`.
+///     @AutoTypeCodable var scheduledAt: Date?
+/// }
+///
+/// let json = """
+/// 	{
+/// 		"intValue": "42",
+/// 		"doubleValue": 3.14,
+/// 		"price": "10.50",
+/// 		"scheduledAt": "01.01.2021 13:45"
+/// 	}
+/// 	"""
+/// 	.data(using: .utf8)
+/// 	.forceUnwrap(because: "Valid JSON string will be converted to Data")
+///
+/// let decoded = try JSONDecoder()
+/// 	.decode(Payload.self, from: json)
+///
+/// // decoded.intValue == 42
+/// // decoded.doubleValue == 3.14
+/// // decoded.price == 10.50
+/// // decoded.scheduledAt != nil
+/// ```
 @propertyWrapper
-public struct AutoTypeCodable <T>: Codable // , Sendable
-	where T: LosslessStringConvertible,
-		  T: Codable
-		  // T: Sendable
-{
+public struct AutoTypeCodable <T>: Codable where T: LosslessStringConvertible,
+												 T: Codable {
+	
 	private typealias LosslessStringCodable = LosslessStringConvertible & Codable
 	
+	/// The underlying value managed by the property wrapper.
 	public var wrappedValue: T
 
+	/// Creates the wrapper with an initial value.
+	/// - Parameter wrappedValue: The value to store and later encode/decode.
 	public init(wrappedValue: T) {
 		self.wrappedValue = wrappedValue
 	}
 	
+	/// Decodes the wrapped value from the given decoder, accepting multiple source types
+	/// as described in the type documentation.
+	/// - Parameter decoder: The decoder to read data from.
+	/// - Throws: Any error thrown by the underlying `Decodable` implementations
+	///   or if no compatible representation can be converted to `T`.
 	public init(from decoder: Decoder) throws {
 		do {
 			self.wrappedValue = try T.init(from: decoder)
 		} catch let error {
 			
-			func decode <D: LosslessStringCodable> (
-				_: D.Type
-			) -> (Decoder) -> LosslessStringCodable? {
-				{
-					try? D.init(from: $0)
-				}
+			func decode<D: LosslessStringCodable>(_: D.Type) -> (Decoder) -> LosslessStringCodable? {
+				{ try? D.init(from: $0) }
 			}
 			
 			func decodeBoolFromNSNumber() -> (Decoder) -> LosslessStringCodable? {
-				{
-					(try? Int.init(from: $0))
-						.flatMap {
-							Bool(exactly: NSNumber(value: $0))
+				{ decoder in
+					(try? Int(from: decoder))
+						.flatMap { int in
+							Bool(exactly: NSNumber(value: int))
 						}
 				}
 			}
@@ -63,13 +121,20 @@ public struct AutoTypeCodable <T>: Codable // , Sendable
 			]
 			
 			guard let rawValue = types.lazy.compactMap({ $0(decoder) }).first,
-				  let value = T.init("\(rawValue)")
+				  let value = T("\(rawValue)")
 			else { throw error }
 			
 			self.wrappedValue = value
 		}
 	}
 	
+	/// Encodes the wrapped value using `T`'s `Encodable` conformance.
+	///
+	/// The value is first round‑tripped through `String(describing:)` and `T.init(_:)`
+	/// to preserve the canonical representation before encoding.
+	/// - Parameter encoder: The encoder to write data to.
+	/// - Throws: `EncodingError.invalidValue` if the value cannot be reconstructed
+	///   from its string description.
 	public func encode(to encoder: Encoder) throws {
 		let string = String(describing: wrappedValue)
 		
@@ -83,17 +148,45 @@ public struct AutoTypeCodable <T>: Codable // , Sendable
 }
 
 public extension KeyedDecodingContainer {
-	func decode<T>(_: AutoTypeCodable<T>.Type, forKey key: Key) -> AutoTypeCodable<T> where T: TypedOptionalConvertible {
-		(try? decodeIfPresent(AutoTypeCodable<T>.self, forKey: key)) ?? AutoTypeCodable<T>(wrappedValue: .none)
+	/// Decodes an `AutoTypeCodable<T>` for the given key, defaulting to `T.none`
+	/// when the key is missing or the value is `null`.
+	///
+	/// This overload is available when `T` is an optional‑like type
+	/// that conforms to `TypedOptionalConvertible`.
+	/// - Parameters:
+	///   - type: The `AutoTypeCodable<T>` type to decode.
+	///   - key: The key that the decoded value is associated with.
+	/// - Returns: A wrapper containing the decoded value or `.none`.
+	func decode<T: TypedOptionalConvertible>(
+		_: AutoTypeCodable<T>.Type,
+		forKey key: Key
+	) -> AutoTypeCodable<T> {
+		(try? decodeIfPresent(AutoTypeCodable<T>.self, forKey: key))
+		?? AutoTypeCodable<T>(wrappedValue: .none)
 	}
 }
 
-// extension Optional: @retroactive CustomStringConvertible where Wrapped: LosslessStringConvertible { }
 extension Optional: @retroactive LosslessStringConvertible where Wrapped: LosslessStringConvertible {
+	/// Creates an optional from a string by delegating
+	/// to the wrapped type's lossless initializer.
+	/// - Returns:
+	///   - If `Wrapped(description)` succeeds
+	///     ```swift
+	///     .some(value)
+	///     ```
+	///   - Otherwise
+	///     ```swift
+	///     nil
+	///     ```
+	/// - Parameter description: A string representation of the wrapped value.
 	public init?(_ description: String) {
 		self = Wrapped.init(description)
 	}
 	
+	/// A textual representation of the optional.
+	/// - Returns:
+	///   - An empty string for `.none`
+	///   - The wrapped value's description for `.some`
 	public var description: String {
 		switch self {
 		case .none: return .empty
@@ -103,12 +196,15 @@ extension Optional: @retroactive LosslessStringConvertible where Wrapped: Lossle
 }
 
 extension AutoTypeCodable: Equatable where T: Equatable {
+	/// Returns `true` if both wrappers contain equal values.
 	public static func == (lhs: AutoTypeCodable<T>, rhs: AutoTypeCodable<T>) -> Bool {
 		lhs.wrappedValue == rhs.wrappedValue
 	}
 }
 
 extension AutoTypeCodable: Hashable where T: Hashable {
+	/// Hashes the wrapped value into the provided hasher.
+	/// - Parameter hasher: The hasher to use when combining the components of this instance.
 	public func hash(into hasher: inout Hasher) {
 		hasher.combine(wrappedValue)
 	}
@@ -119,35 +215,45 @@ extension AutoTypeCodable: Sendable where T: Sendable { }
 // MARK: Adopt
 
 extension Date: @retroactive LosslessStringConvertible {
+	/// Creates a `Date` from a string using a best‑effort strategy.
+	///
+	/// Attempts to parse using the `"dd.MM.yyyy HH:mm"` format in the current time zone;
+	/// otherwise falls back to `DateFormatter().date(from:)`.
+	/// - Parameter description: A string representation of a date.
 	public init?(_ description: String) {
 		#if swift(>=5.5)
-		if #available(iOS 15.0, *) {
-			do {
-				try self.init(
-					description,
-					strategy: Date.ParseStrategy(
-						format: "\(day: .twoDigits).\(month: .twoDigits).\(year: .defaultDigits) \(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\(minute: .twoDigits)",
-						timeZone: .current
-					)
+		do {
+			try self.init(
+				description,
+				strategy: Date.ParseStrategy(
+					format: """
+						\(day: .twoDigits).\(month: .twoDigits).\(year: .defaultDigits) \
+						\(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .zeroBased)):\
+						\(minute: .twoDigits)
+						""",
+					timeZone: .current
 				)
-			} catch {
+			)
+		} catch {
+			if let date = DateFormatter().date(from: description) {
+				self = date
+			} else {
 				return nil
 			}
-		} else if let date = DateFormatter().date(from: description) {
-			self = date
-		} else {
-			return nil
 		}
-		#endif
+		#else
 		if let date = DateFormatter().date(from: description) {
 			self = date
 		} else {
 			return nil
 		}
+		#endif
 	}
 }
 
 extension Decimal: @retroactive LosslessStringConvertible {
+	/// Creates a `Decimal` from its string representation.
+	/// - Parameter description: A string representation of a decimal number.
 	public init?(_ description: String) {
 		self.init(string: description)
 	}
@@ -155,37 +261,82 @@ extension Decimal: @retroactive LosslessStringConvertible {
 
 // MARK: - Defaulted
 
+/// A variant of `AutoTypeCodable` that tolerates decoding failures
+/// by providing a reasonable default value.
+///
+/// Use this when you prefer resilient decoding and want to avoid throwing
+/// for inconsistent server payloads.
+/// ## Defaulting behavior
+/// - If decoding fails or the value is missing, attempts to build a default
+///   by trying `T("false")` and then `T("0")`.
+/// - For optional‑like `T` (i.e., types conforming to `TypedOptionalConvertible`),
+///   defaults to `.none` if both attempts fail.
+/// ## Usage
+/// ```swift
+/// struct LossyPayload: Codable {
+///     // Defaults to 0 when value is missing or invalid
+///     @LossyAutoTypeCodable var count: Int
+///
+///     // Defaults to `.none` when value is missing or invalid
+///     @LossyAutoTypeCodable var maybeID: Int?
+/// }
+///
+/// // Missing keys: produces defaults
+/// let missing = try JSONDecoder()
+/// 	.decode(LossyPayload.self, from: Data("{}".utf8))
+/// // missing.count == 0
+/// // missing.maybeID == nil
+///
+/// // Invalid types: still produces defaults
+/// let invalidJSON = """
+/// 	{
+/// 		"count": "oops",
+/// 		"maybeID": "nope"
+/// 	}
+/// 	"""
+/// 	.data(using: .utf8)
+/// 	.forceUnwrap(because: "Valid JSON string will be converted to Data")
+/// let invalid = try JSONDecoder()
+/// 	.decode(LossyPayload.self, from: invalidJSON)
+/// // invalid.count == 0
+/// // invalid.maybeID == nil
+/// ```
 @propertyWrapper
-public struct LossyAutoTypeCodable <T>: Codable
+public struct LossyAutoTypeCodable<T>: Codable
 	where T: LosslessStringConvertible,
 		  T: Codable
 {
 	private typealias LosslessStringCodable = LosslessStringConvertible & Codable
 	
+	/// The underlying value managed by the property wrapper.
+	/// When decoding fails, this may be initialized to a default value.
 	public var wrappedValue: T
 	
+	/// Creates the wrapper with an initial value.
+	/// - Parameter wrappedValue: The value to store and later encode/decode.
 	public init(wrappedValue: T) {
 		self.wrappedValue = wrappedValue
 	}
 	
+	/// Decodes the wrapped value from the given decoder.
+	/// If decoding fails, a default value is used as described in the type documentation.
+	/// - Parameter decoder: The decoder to read data from.
 	public init(from decoder: Decoder) throws {
 		do {
 			self.wrappedValue = try T.init(from: decoder)
 		} catch let error {
 			
-			func decode <D: LosslessStringCodable> (
-				_: D.Type
-			) -> (Decoder) -> LosslessStringCodable? {
-				{
-					try? D.init(from: $0)
+			func decode <D: LosslessStringCodable> (_: D.Type) -> (Decoder) -> LosslessStringCodable? {
+				{ decoder in
+					try? D(from: decoder)
 				}
 			}
 			
 			func decodeBoolFromNSNumber() -> (Decoder) -> LosslessStringCodable? {
-				{
-					(try? Int.init(from: $0))
-						.flatMap {
-							Bool(exactly: NSNumber(value: $0))
+				{ decoder in
+					(try? Int.init(from: decoder))
+						.flatMap { int in
+							Bool(exactly: NSNumber(value: int))
 						}
 				}
 			}
@@ -209,13 +360,16 @@ public struct LossyAutoTypeCodable <T>: Codable
 			]
 			
 			guard let rawValue = types.lazy.compactMap({ $0(decoder) }).first,
-				  let value = T.init("\(rawValue)")
+				  let value = T("\(rawValue)")
 			else { throw error }
 			
 			self.wrappedValue = value
 		}
 	}
 	
+	/// Encodes the wrapped value using `T`'s `Encodable` conformance.
+	/// - SeeAlso: `AutoTypeCodable.encode(to:)` for details on the round‑trip strategy.
+	/// - Parameter encoder: The encoder to write data to.
 	public func encode(to encoder: Encoder) throws {
 		let string = String(describing: wrappedValue)
 		
@@ -229,35 +383,65 @@ public struct LossyAutoTypeCodable <T>: Codable
 }
 
 public extension KeyedDecodingContainer {
-	func decode<T>(_: LossyAutoTypeCodable<T>.Type, forKey key: Key) throws -> LossyAutoTypeCodable<T> {
+	/// Decodes a `LossyAutoTypeCodable<T>` for the given key.
+	///
+	/// If decoding fails or the value is missing, returns a wrapper
+	/// initialized with a default value derived from `T("false")` or `T("0")`.
+	/// - Parameters:
+	///   - type: The `LossyAutoTypeCodable<T>` type to decode.
+	///   - key: The key that the decoded value is associated with.
+	/// - Returns: A wrapper containing the decoded or default value.
+	/// - Throws: `DecodingError.dataCorrupted` if no default can be created.
+	func decode<T>(
+		_: LossyAutoTypeCodable<T>.Type,
+		forKey key: Key
+	) throws -> LossyAutoTypeCodable<T> {
 		if let decoded = try? decodeIfPresent(LossyAutoTypeCodable<T>.self, forKey: key) {
 			return decoded
 		} else if let defaultValue = T("false") ?? T("0") {
 			return .init(wrappedValue: defaultValue)
 		} else {
-			throw DecodingError.dataCorruptedError(forKey: key, in: self, debugDescription: "Neither can decode \(T.self) value nor create a default one")
+			throw DecodingError.dataCorruptedError(
+				forKey: key,
+				in: self,
+				debugDescription: "Neither can decode \(T.self) value nor create a default one"
+			)
 		}
 	}
 	
-	/// Optional
-	func decode<T>(_: LossyAutoTypeCodable<T>.Type, forKey key: Key) throws -> LossyAutoTypeCodable<T> where T: TypedOptionalConvertible {
+	/// Decodes a `LossyAutoTypeCodable<T>` for the given key when `T` is optional‑like.
+	///
+	/// If decoding fails or the value is missing, returns a wrapper initialized
+	/// with a default value derived from `T("false")` or `T("0")`, or `.none`
+	/// if neither can be constructed.
+	/// - Parameters:
+	///   - type: The `LossyAutoTypeCodable<T>` type to decode.
+	///   - key: The key that the decoded value is associated with.
+	/// - Returns: A wrapper containing the decoded or default value.
+	func decode<T: TypedOptionalConvertible>(
+		_: LossyAutoTypeCodable<T>.Type,
+		forKey key: Key
+	) throws -> LossyAutoTypeCodable<T> {
 		if let decoded = try? decodeIfPresent(LossyAutoTypeCodable<T>.self, forKey: key) {
-			return decoded
+			decoded
 		} else if let defaultValue = T("false") ?? T("0") {
-			return .init(wrappedValue: defaultValue)
+			.init(wrappedValue: defaultValue)
 		} else {
-			return .init(wrappedValue: .none)
+			.init(wrappedValue: .none)
 		}
 	}
 }
 
 extension LossyAutoTypeCodable: Equatable where T: Equatable {
+	/// Returns `true` if both wrappers contain equal values.
 	public static func == (lhs: LossyAutoTypeCodable<T>, rhs: LossyAutoTypeCodable<T>) -> Bool {
 		lhs.wrappedValue == rhs.wrappedValue
 	}
 }
 
 extension LossyAutoTypeCodable: Hashable where T: Hashable {
+	/// Hashes the wrapped value into the provided hasher.
+	/// - Parameter hasher: The hasher to use when combining the components of this instance.
 	public func hash(into hasher: inout Hasher) {
 		hasher.combine(wrappedValue)
 	}

--- a/Sources/QizhKit/Structures/Codable/HexStringColor.swift
+++ b/Sources/QizhKit/Structures/Codable/HexStringColor.swift
@@ -89,6 +89,14 @@ public struct HexStringColorsPair: Codable,
 			"[\(light == Self.default.light ? "null" : light.description.inQuotes), \(dark == Self.default.dark ? "null" : dark.description.inQuotes)]"
 		}
 	}
+	
+	public var color: Color {
+		if light == dark {
+			light.color
+		} else {
+			.fromHexColors(light: light, dark: dark)
+		}
+	}
 }
 
 // MARK: - Hex Color

--- a/Sources/QizhKit/Structures/Codable/HexStringColor.swift
+++ b/Sources/QizhKit/Structures/Codable/HexStringColor.swift
@@ -16,6 +16,83 @@ import UIKit
 import AppKit
 #endif
 
+// MARK: - Pair of Hex Colors
+
+public struct HexStringColorsPair: Codable,
+								   Hashable,
+								   Sendable,
+								   WithDefault,
+								   CustomStringConvertible,
+								   ExpressibleByStringLiteral,
+								   ExpressibleByArrayLiteral {
+	
+	public let light: HexStringColor
+	public let dark: HexStringColor
+	
+	public init(light: HexStringColor, dark: HexStringColor) {
+		self.light = light
+		self.dark = dark
+	}
+	
+	@_disfavoredOverload
+	public init(light: HexStringColor?, dark: HexStringColor?) {
+		self.init(light: light ?? Self.default.light, dark: dark ?? Self.default.dark)
+	}
+	
+	@inlinable public init(_ light: HexStringColor, _ dark: HexStringColor) {
+		self.init(light: light, dark: dark)
+	}
+	
+	@inlinable public init(same hexColor: HexStringColor) {
+		self.init(light: hexColor, dark: hexColor)
+	}
+	
+	@inlinable public init(_ colors: HexStringColor...) { self.init(colors) }
+	public init(_ colors: [HexStringColor]) {
+		switch colors.count {
+		case 0: self = .default
+		case 1: self.init(same: colors[0])
+		default: self.init(light: colors[0], dark: colors[1])
+		}
+	}
+	
+	public init(stringLiteral value: String) {
+		let invertedHexColorSet = HexStringColor.characterSet.inverted
+		
+		let hexColors = value
+			.components(separatedBy: invertedHexColorSet)
+			.compactMap { s in
+				s.replacing(invertedHexColorSet, with: .empty).nonEmpty
+			}
+			.map { s in
+				HexStringColor(stringLiteral: s)
+			}
+		
+		self.init(hexColors)
+	}
+	
+	public init(arrayLiteral elements: UInt64...) {
+		self.init(elements.map(HexStringColor.init(integerLiteral:)))
+	}
+	
+	public static let `default`: HexStringColorsPair = .init(
+		light: .violentVioletLight,
+		dark: .violentVioletDark
+	)
+	
+	public var description: String {
+		if isDefault {
+			"default"
+		} else if light == dark {
+			light.description
+		} else {
+			"[\(light == Self.default.light ? "null" : light.description.inQuotes), \(dark == Self.default.dark ? "null" : dark.description.inQuotes)]"
+		}
+	}
+}
+
+// MARK: - Hex Color
+
 public struct HexStringColor: Codable,
 							  Hashable,
 							  Sendable,
@@ -26,9 +103,13 @@ public struct HexStringColor: Codable,
 	public let value: UInt64
 	public let hasAlphaChannel: Bool
 	
+	public static let characterSet = CharacterSet(charactersIn: "#0123456789abcdefABCDEF")
+	
 	public static let `default`: HexStringColor = .init(0x000000)
-	public static let black: HexStringColor = .init(0x000000)
-	public static let white: HexStringColor = .init(0xffffff)
+	public static let black: HexStringColor = 0x000000
+	public static let white: HexStringColor = 0xffffff
+	public static let violentVioletLight: HexStringColor = 0x1D0E64
+	public static let violentVioletDark: HexStringColor = 0xA7B9E3
 	
 	/// Creates a hexadecimal color from a numeric value.
 	///

--- a/Sources/QizhKit/Structures/Environment Keys/IsInPreviewEnvironmentKey.swift
+++ b/Sources/QizhKit/Structures/Environment Keys/IsInPreviewEnvironmentKey.swift
@@ -8,19 +8,12 @@
 
 import SwiftUI
 
-public struct IsInPreviewKey: EnvironmentKey {
-	public static let defaultValue: Bool = false
+extension EnvironmentValues {
+	@Entry public var isInPreview: Bool = false
 }
 
-public extension EnvironmentValues {
-	var isInPreview: Bool {
-		get { self[IsInPreviewKey.self] }
-		set { self[IsInPreviewKey.self] = newValue }
-	}
-}
-
-public extension View {
-	func isInPreview() -> some View {
+extension View {
+	public func isInPreview() -> some View {
 		environment(\.isInPreview, true)
 	}
 }

--- a/Sources/QizhKit/Structures/Protocols/EmptyTestable.swift
+++ b/Sources/QizhKit/Structures/Protocols/EmptyTestable.swift
@@ -102,6 +102,17 @@ extension LocalizedStringKey: EmptyComparable {
 	public static var empty: LocalizedStringKey { "" }
 }
 
+extension String.LocalizationValue: EmptyComparable {
+	public static var empty: String.LocalizationValue {
+		String.LocalizationValue(.empty)
+	}
+}
+
+extension LocalizedStringResource: EmptyComparable {
+	public static var empty: LocalizedStringResource {
+		LocalizedStringResource(.empty, table: "Special Cases", locale: .en_US, bundle: .qizhKit.forLocale(.en_US), comment: "Empty string, used to adopt EmptyComparable") }
+}
+
 extension Text: EmptyComparable {
 	public static let empty = Text(verbatim: .empty)
 }

--- a/Sources/QizhKit/Structures/Shapes/ShapeBuilder.swift
+++ b/Sources/QizhKit/Structures/Shapes/ShapeBuilder.swift
@@ -13,26 +13,6 @@ import SwiftUI
 
 
 
-// MARK: Any
-
-/// A type-erased `Shape`.
-///
-/// SwiftUI provides `AnyShapeStyle`, but a type-erased `Shape` is still useful for
-/// result-builder scenarios (e.g. `buildLimitedAvailability`).
-public struct AnyShape: Shape {
-	private let _path: @Sendable (CGRect) -> Path
-
-	public init<S: Shape>(_ shape: S) {
-		self._path = { rect in
-			shape.path(in: rect)
-		}
-	}
-
-	public func path(in rect: CGRect) -> Path {
-		_path(rect)
-	}
-}
-
 // MARK: Insetted
 
 /// A `Shape` wrapper that applies an inset (`InsettableShape.inset(by:)`) lazily.
@@ -259,28 +239,6 @@ public struct ShapeBuilder {
 	public static func buildEither<S1: Shape, S2: Shape>(second: S2) -> EitherShape<S1, S2> {
 		.second(second)
 	}
-	/*
-	public static func buildEither<First: InsettableShape, Second: InsettableShape>(
-		first: First
-	) -> EitherShape<First, Second> {
-		.first(first)
-	}
-	public static func buildEither<First: InsettableShape, Second: InsettableShape>(
-		second: Second
-	) -> EitherShape<First, Second> {
-		.second(second)
-	}
-	public static func buildEither<First: InsettableShape, Second: Shape>(
-		first: First
-	) -> EitherShape<First, Second> {
-		.first(first)
-	}
-	public static func buildEither<First: Shape, Second: InsettableShape>(
-		second: Second
-	) -> EitherShape<First, Second> {
-		.second(second)
-	}
-	*/
 	
 	// MARK: 5 - Handle `for`..`in`
 	
@@ -290,7 +248,19 @@ public struct ShapeBuilder {
 	// MARK: 6 - Handle `if #available(...) { ... }` in a builder context
 	
 	/// Type-erases shapes across availability boundaries (`if #available`).
-	public static func buildLimitedAvailability(_ s: some Shape) -> AnyShape { AnyShape(s) }
+	public static func buildLimitedAvailability(
+		_ s: some Shape
+	) -> AnyShape {
+		AnyShape(s)
+	}
+	
+	/// Type-erases shapes across availability boundaries (`if #available`)
+	/// for `InsettableShape`.
+	public static func buildLimitedAvailability(
+		_ s: some InsettableShape
+	) -> AnyInsettableShape {
+		AnyInsettableShape(s)
+	}
 	
 	// MARK: 7 - Optionally post-process the final Component into a different return type
 	

--- a/Sources/QizhKit/Structures/Shapes/ShapeBuilder.swift
+++ b/Sources/QizhKit/Structures/Shapes/ShapeBuilder.swift
@@ -9,57 +9,127 @@
 
 import SwiftUI
 
-@resultBuilder
-public struct ShapeBuilder {
-	public static func buildBlock<C0: Shape>(_ c0: C0) -> C0 { c0 }
-}
+// MARK: - Helper Shapes
 
-extension ShapeBuilder {
-	public static func buildBlock() -> EmptyShape { EmptyShape() }
-}
 
-public struct EmptyShape: Shape {
-	public func path(in rect: CGRect) -> Path { Path() }
-}
 
-extension ShapeBuilder {
-	public static func buildOptional<C0: Shape>(_ c0: C0?) -> OptionalShape<C0> {
-		OptionalShape(c0)
+// MARK: Any
+
+/// A type-erased `Shape`.
+///
+/// SwiftUI provides `AnyShapeStyle`, but a type-erased `Shape` is still useful for
+/// result-builder scenarios (e.g. `buildLimitedAvailability`).
+public struct AnyShape: Shape {
+	private let _path: @Sendable (CGRect) -> Path
+
+	public init<S: Shape>(_ shape: S) {
+		self._path = { rect in
+			shape.path(in: rect)
+		}
+	}
+
+	public func path(in rect: CGRect) -> Path {
+		_path(rect)
 	}
 }
 
-extension ShapeBuilder {
-	public static func buildLimitedAvailability(_ component: some Shape) -> AnyShape {
-		AnyShape(component)
+// MARK: Insetted
+
+/// A `Shape` wrapper that applies an inset (`InsettableShape.inset(by:)`) lazily.
+///
+/// You can use it directly:
+/// ```swift
+/// let s = InsettedShape(Circle(), by: 12)
+/// ```
+/// Or as a property wrapper when you want to store an insettable shape plus its inset:
+/// ```swift
+/// @InsettedShape(by: 8) var shape = Capsule()
+/// ```
+/// - Note: This wrapper conforms to both `Shape` and `InsettableShape`.
+@propertyWrapper
+public struct InsettedShape<S: InsettableShape>: InsettableShape, Updatable {
+	public let wrappedValue: S
+	public fileprivate(set) var insetAmount: CGFloat
+
+	public var projectedValue: Self { self }
+
+	public init(wrappedValue: S) {
+		self.init(wrappedValue, by: .zero)
+	}
+
+	public init(wrappedValue: S, by amount: CGFloat) {
+		self.init(wrappedValue, by: amount)
+	}
+
+	/// Creates a wrapper around `wrappedValue` with an initial inset amount.
+	/// - Parameters:
+	///   - wrappedValue: The underlying insettable shape.
+	///   - amount: Initial inset amount.
+	public init(_ wrappedValue: S, by amount: CGFloat = .zero) {
+		self.wrappedValue = wrappedValue
+		self.insetAmount = amount
+	}
+	
+	/// Returns the path of the wrapped shape after applying the current inset.
+	public func path(in rect: CGRect) -> Path {
+		wrappedValue
+			.inset(by: insetAmount)
+			.path(in: rect)
+	}
+	
+	/// Returns a copy with the inset amount increased by `amount`.
+	public nonisolated func inset(by amount: CGFloat) -> InsettedShape {
+		updating { s in
+			s.insetAmount += amount
+		}
 	}
 }
 
-public struct OptionalShape<Content: Shape>: Shape {
-	public let content: Content?
+// MARK: Optional
 
-	public init(_ content: Content?) {
+/// A `Shape` that conditionally renders another shape.
+///
+/// When `content` is `nil`, the resulting path is empty.
+public struct OptionalShape<Wrapped: Shape>: Shape {
+	public let content: Wrapped?
+	
+	/// Creates an optional shape.
+	/// - Parameter content: The wrapped shape, or `nil`.
+	public init(_ content: Wrapped?) {
 		self.content = content
 	}
-
+	
+	/// Returns the wrapped shape’s path, or an empty path when `content` is `nil`.
 	public func path(in rect: CGRect) -> Path {
 		content?.path(in: rect) ?? Path()
 	}
 }
 
-extension ShapeBuilder {
-	public static func buildEither<First: Shape, Second: Shape>(first: First) -> EitherShape<First, Second> {
-		.first(first)
-	}
-
-	public static func buildEither<First: Shape, Second: Shape>(second: Second) -> EitherShape<First, Second> {
-		.second(second)
+extension OptionalShape: InsettableShape where Wrapped: InsettableShape {
+	public nonisolated func inset(by amount: CGFloat) -> InsettedShape<OptionalShape<Wrapped>> {
+		InsettedShape(self, by: amount)
 	}
 }
 
-public enum EitherShape<First: Shape, Second: Shape>: Shape {
-	case first(First)
-	case second(Second)
+// MARK: Empty
 
+/// A `Shape` whose path is always empty.
+/// - Note: This is intentionally named like SwiftUI’s concept of an “empty shape”,
+///   but scoped to this module.
+public struct EmptyShape: Shape {
+	public func path(in rect: CGRect) -> Path { Path() }
+}
+
+// MARK: Either
+
+/// A `Shape` that holds one of two possible shape types.
+///
+/// This is primarily used by `ShapeBuilder` to support `if/else` and `switch`.
+public enum EitherShape<S1: Shape, S2: Shape>: Shape {
+	case first(S1)
+	case second(S2)
+
+	/// Returns the path of the stored case.
 	public func path(in rect: CGRect) -> Path {
 		switch self {
 		case .first(let first): first.path(in: rect)
@@ -68,48 +138,189 @@ public enum EitherShape<First: Shape, Second: Shape>: Shape {
 	}
 }
 
-extension ShapeBuilder {
-	public static func buildBlock<C0: Shape, C1: Shape>(_ c0: C0, _ c1: C1) -> Tuple2Shape<C0, C1> {
-		Tuple2Shape(c0, c1)
+extension EitherShape: InsettableShape where S1: InsettableShape, S2: InsettableShape {
+	public nonisolated func inset(
+		by amount: CGFloat
+	) -> InsettedShape<EitherShape<S1, S2>> {
+		InsettedShape(self, by: amount)
 	}
 }
 
-public struct Tuple2Shape<C0: Shape, C1: Shape>: Shape {
-	public let tuple: (C0, C1)
+// MARK: Multi Shape
 
-	public init(_ c0: C0, _ c1: C1) {
-		tuple = (c0, c1)
+/// A compile-time-sized collection of shapes combined into a single `Path`.
+///
+/// `MultiShape` stores its children as a variadic generic tuple `(repeat each P)`.
+/// This makes it fast and type-safe, but it also means it cannot be built from a
+/// runtime-sized array.
+///
+/// ```swift
+/// let s = MultiShape(Circle(), Rectangle(), Capsule())
+/// ```
+public struct MultiShape<each P: Shape>: Shape, Updatable {
+	public let shapes: (repeat each P)
+	
+	/// Creates a `MultiShape` from a fixed list of shapes.
+	public init(_ shapes: repeat each P) {
+		self.shapes = (repeat each shapes)
 	}
-
+	
+	/// Returns a single path made by appending each child shape’s path.
 	public func path(in rect: CGRect) -> Path {
-		var path = tuple.0.path(in: rect)
-		path.addPath(tuple.1.path(in: rect))
+		var path: Path = .init()
+		/// Initial way to write this expression
+		/// `_ = (repeat (path.addPath((each shapes).path(in: rect))))`
+		repeat (path.addPath((each shapes).path(in: rect)))
 		return path
 	}
 }
 
-extension ShapeBuilder {
-	public static func buildBlock<C0: Shape, C1: Shape, C2: Shape>(_ c0: C0, _ c1: C1, _ c2: C2) -> Tuple3Shape<C0, C1, C2> {
-		Tuple3Shape(c0, c1, c2)
+extension MultiShape: InsettableShape where repeat each P: InsettableShape {
+	public nonisolated func inset(by amount: CGFloat) -> InsettedShape<Self> {
+		InsettedShape(self, by: amount)
 	}
 }
 
-public struct Tuple3Shape<C0: Shape, C1: Shape, C2: Shape>: Shape {
-	public let tuple: (C0, C1, C2)
+// MARK: Array-backed Multi Shape
 
-	public init(_ c0: C0, _ c1: C1, _ c2: C2) {
-		tuple = (c0, c1, c2)
+/// A runtime-sized collection of shapes combined into a single `Path`.
+///
+/// Use this when you only have an array of shapes
+/// (for example, the output of a `for` loop inside `ShapeBuilder`).
+public struct MultiShapeArray<S: Shape>: Shape, Updatable {
+	public let shapes: [S]
+
+	/// Creates an array-backed multi-shape.
+	/// - Parameter shapes: Shapes to combine, in order.
+	public init(_ shapes: [S]) {
+		self.shapes = shapes
 	}
 
+	/// Returns a single path made by appending each child shape’s path.
 	public func path(in rect: CGRect) -> Path {
-		var path = tuple.0.path(in: rect)
-		path.addPath(tuple.1.path(in: rect))
-		path.addPath(tuple.2.path(in: rect))
+		var path: Path = .init()
+		for shape in shapes {
+			path.addPath(shape.path(in: rect))
+		}
 		return path
 	}
 }
 
-// MARK: Preview
+extension MultiShapeArray: InsettableShape where S: InsettableShape {
+	public nonisolated func inset(by amount: CGFloat) -> InsettedShape<Self> {
+		InsettedShape(self, by: amount)
+	}
+}
+
+// MARK: - Builder
+
+/// A result builder that combines multiple `Shape` statements into a single `Shape`.
+///
+/// ## This builder supports
+/// - Plain blocks (multiple shape statements)
+/// - `if`, `if/else`, and `switch`
+/// - `for` loops (via an array-backed shape)
+/// - Availability checks (`if #available`)
+@resultBuilder
+public struct ShapeBuilder {
+	
+	// MARK: 1 - Combine components from a block
+	
+	/// Builds an empty shape block.
+	public static func buildBlock() -> EmptyShape { EmptyShape() }
+	
+	/// Builds a single-shape block.
+	public static func buildBlock<C0: Shape>(_ c0: C0) -> C0 { c0 }
+	
+	/// Builds a multi-shape block from a fixed list of shapes.
+	public static func buildBlock<each P: Shape>(
+		_ shapes: repeat each P
+	) -> MultiShape<repeat each P> {
+		MultiShape(repeat each shapes)
+	}
+	
+	// MARK: 2 - Lift an expression into Component
+	
+	/// Lifts a `Shape` expression into the builder.
+	public static func buildExpression<S: Shape>(_ expression: S) -> S { expression }
+	
+	// MARK: 3 - Handle `if` without `else`
+	
+	/// Supports `if` without `else` by wrapping an optional shape.
+	public static func buildOptional<S: Shape>(_ os: S?) -> OptionalShape<S> { OptionalShape(os) }
+	
+	// MARK: 4 - Handle `if/else` and `switch`
+	
+	/// Supports `if/else` and `switch` by selecting the first branch.
+	public static func buildEither<S1: Shape, S2: Shape>(first: S1) -> EitherShape<S1, S2> {
+		.first(first)
+	}
+	/// Supports `if/else` and `switch` by selecting the second branch.
+	public static func buildEither<S1: Shape, S2: Shape>(second: S2) -> EitherShape<S1, S2> {
+		.second(second)
+	}
+	/*
+	public static func buildEither<First: InsettableShape, Second: InsettableShape>(
+		first: First
+	) -> EitherShape<First, Second> {
+		.first(first)
+	}
+	public static func buildEither<First: InsettableShape, Second: InsettableShape>(
+		second: Second
+	) -> EitherShape<First, Second> {
+		.second(second)
+	}
+	public static func buildEither<First: InsettableShape, Second: Shape>(
+		first: First
+	) -> EitherShape<First, Second> {
+		.first(first)
+	}
+	public static func buildEither<First: Shape, Second: InsettableShape>(
+		second: Second
+	) -> EitherShape<First, Second> {
+		.second(second)
+	}
+	*/
+	
+	// MARK: 5 - Handle `for`..`in`
+	
+	/// Supports `for` loops by combining an array of shapes.
+	public static func buildArray<S: Shape>(_ ss: [S]) -> MultiShapeArray<S> { MultiShapeArray(ss) }
+	
+	// MARK: 6 - Handle `if #available(...) { ... }` in a builder context
+	
+	/// Type-erases shapes across availability boundaries (`if #available`).
+	public static func buildLimitedAvailability(_ s: some Shape) -> AnyShape { AnyShape(s) }
+	
+	// MARK: 7 - Optionally post-process the final Component into a different return type
+	
+	/// Optionally post-processes the final component.
+	public static func buildFinalResult<S: Shape>(_ component: S) -> S { component }
+	
+	// MARK: 8 - Alternative to `buildBlock` for scaling to “many statements” efficiently
+	
+	/// Starts an incremental build for large blocks.
+	public static func buildPartialBlock<C0: Shape>(first: C0) -> C0 { first }
+
+	/// Appends a shape to an incremental build.
+	public static func buildPartialBlock<Acc: Shape, Next: Shape>(
+		accumulated: Acc,
+		next: Next
+	) -> MultiShape<Acc, Next> {
+		MultiShape(accumulated, next)
+	}
+
+	/// Appends a shape to an incremental build, flattening the tuple pack.
+	public static func buildPartialBlock<each P: Shape, Next: Shape>(
+		accumulated: MultiShape<repeat each P>,
+		next: Next
+	) -> MultiShape<repeat each P, Next> {
+		MultiShape(repeat each accumulated.shapes, next)
+	}
+}
+
+// MARK: - Preview
+
 #if DEBUG
 fileprivate struct Test: View {
 	var body: some View {
@@ -125,6 +336,8 @@ fileprivate struct Test: View {
 		Rectangle()
 		Capsule()
 			.scale(y: 0.5, anchor: .center)
+		Ellipse()
+			.inset(by: 20)
 	}
 }
 

--- a/Sources/QizhKit/Structures/Type Erase/AnyInsettableShape.swift
+++ b/Sources/QizhKit/Structures/Type Erase/AnyInsettableShape.swift
@@ -13,7 +13,7 @@ public struct AnyInsettableShape: InsettableShape, Sendable {
 	private let makeInset: @Sendable (CGFloat) -> AnyInsettableShape
 
 	public init<S: InsettableShape & Sendable>(_ shape: S) {
-		// Capture a copy of the shape to ensure it's Sendable
+		/// Capture a copy of the shape to ensure it's Sendable
 		let shapeCopy = shape
 		makePath = { rect in shapeCopy.path(in: rect) }
 		makeInset = { amount in AnyInsettableShape(shapeCopy.inset(by: amount)) }

--- a/Tests/QizhKitTests/AutoTypeCodableTests.swift
+++ b/Tests/QizhKitTests/AutoTypeCodableTests.swift
@@ -1,0 +1,145 @@
+#if swift(>=6.2) && canImport(Testing)
+import Testing
+import Foundation
+@testable import QizhKit
+
+private struct MixedPayload: Codable, Equatable {
+	@AutoTypeCodable var int: Int
+	@AutoTypeCodable var double: Double
+	@AutoTypeCodable var decimal: Decimal
+	@AutoTypeCodable var bool: Bool
+	@AutoTypeCodable var date: Date?
+	
+	init(
+		int: Int,
+		double: Double,
+		decimal: Decimal,
+		bool: Bool,
+		date: Date?
+	) {
+		self.int = int
+		self.double = double
+		self.decimal = decimal
+		self.bool = bool
+		self.date = date
+	}
+}
+
+private struct LossyPayload: Codable, Equatable {
+	@LossyAutoTypeCodable var int: Int
+	@LossyAutoTypeCodable var optInt: Int?
+}
+
+@Suite("AutoTypeCodable tests")
+struct AutoTypeCodableTests {
+	private let dateFormatter: DateFormatter = {
+		let formatter = DateFormatter()
+		formatter.dateFormat = "dd.MM.yyyy HH:mm"
+		formatter.locale = Locale(identifier: "en_US_POSIX")
+		return formatter
+	}()
+	
+	private func date(_ str: String) -> Date {
+		guard let d = dateFormatter.date(from: str) else {
+			fatalError("Invalid date string for test: \(str)")
+		}
+		return d
+	}
+	
+	@Test("Decoding mixed representations")
+	func testDecodingMixedRepresentations() throws {
+		let json = """
+			{
+				"int": "42",
+				"double": 3.1415,
+				"decimal": "2.71828",
+				"bool": 1,
+				"date": "13.12.2025 14:30"
+			}
+			"""
+		let data = Data(json.utf8)
+		let decoded = try JSONDecoder().decode(MixedPayload.self, from: data)
+		
+		#expect(decoded.int == 42)
+		#expect(abs(decoded.double - 3.1415) <= 0.00001)
+		#expect(decoded.decimal == Decimal(string: "2.71828"))
+		#expect(decoded.bool == true)
+		
+		let d = try #require(decoded.date, "Date decoding failed unexpectedly")
+		/// Compare by reformatting to string to avoid TZ issues
+		let decodedDateStr = dateFormatter.string(from: d)
+		#expect(decodedDateStr == "13.12.2025 14:30")
+	}
+	
+	@Test("Round-trip encoding and decoding")
+	func testRoundTripEncodesAndDecodes() throws {
+		let original = MixedPayload(
+			int: 7,
+			double: 1.618,
+			decimal: Decimal(string: "0.57721")!,
+			bool: false,
+			date: date("01.01.2024 00:00")
+		)
+		let encoder = JSONEncoder()
+		let data = try encoder.encode(original)
+		
+		let decoder = JSONDecoder()
+		let decoded = try decoder.decode(MixedPayload.self, from: data)
+		#expect(decoded == original)
+	}
+	
+	@Test("Null optional date yields nil during decoding")
+	func testDecodingNullOptionalDateYieldsNil() throws {
+		let json = """
+			{
+				"int": 0,
+				"double": 0,
+				"decimal": 0,
+				"bool": 0,
+				"date": null
+			}
+			"""
+		let decoded = try JSONDecoder().decode(MixedPayload.self, from: Data(json.utf8))
+		#expect(decoded.date == nil)
+	}
+	
+	@Suite("LossyAutoTypeCodable")
+	struct LossyAutoTypeCodableTests {
+		@Test("Missing keys produce default and nil")
+		func testMissingKeysProduceDefaultAndNil() throws {
+			let json = "{}"
+			let decoded = try JSONDecoder().decode(LossyPayload.self, from: Data(json.utf8))
+			#expect(decoded.int == 0)
+			#expect(decoded.optInt == nil)
+		}
+		
+		@Test("Invalid types produce default and nil")
+		func testInvalidTypesProduceDefaultAndNil() throws {
+			let json = """
+				{
+					"int": "not a number",
+					"optInt": "also no number"
+				}
+				"""
+			let decoded = try JSONDecoder().decode(LossyPayload.self, from: Data(json.utf8))
+			#expect(decoded.int == 0)
+			#expect(decoded.optInt == nil)
+		}
+		
+		@Test("Valid values decode correctly")
+		func testValidValuesDecodeCorrectly() throws {
+			let json = """
+				{
+					"int": 123,
+					"optInt": 456
+				}
+				"""
+			let decoded = try JSONDecoder().decode(LossyPayload.self, from: Data(json.utf8))
+			#expect(decoded.int == 123)
+			#expect(decoded.optInt == 456)
+		}
+	}
+}
+
+#endif
+


### PR DESCRIPTION
## Summary

This PR introduces multiple enhancements to `QizhKit`, including:

### Core Features
- **HDR Support**: Refactored `Package.swift` to introduce trait-based Swift settings for HDR support, centralizing environment checks and trait definitions
- **New `QizhKit` Module**: Added `Sources/QizhKit/QizhKit.swift` with conditional HDR flag test and Bundle extension for module access

### UI Enhancements
- **`ShapeBuilder` Improvements**: 
  - Introduced type-erased shapes and enhanced support for optional, either, and multi-shape compositions
  - Added property wrapper for insettable shapes
  - Expanded result builder capabilities for `SwiftUI`-style shape composition
- **Advanced Border Helpers**: New convenience methods for filling and stroking `InsettableShape` with custom border positioning, thickness, and style
- **Material Shape Styles**: Added static properties for various `Material` styles to `AnyShapeStyle`

### Data Model Improvements
- **`HexStringColorsPair`**: Added computed color property that returns `light` color if both variants are equal, or combined color using `.fromHexColors` otherwise
- **`RailsModel`**: Changed default `id` property type from `UInt8` to `UInt` for broader compatibility

### Extensions & Utilities
- **Collection Casting**: Enhanced `asArray` and `asSet` extensions for `Sequence`, `Slice`, and `RangeReplaceableCollection` with detailed documentation
- **`EmptyComparable`**: Extended conformance to `String.LocalizationValue` & `LocalizedStringResource`

### Documentation & Tests
- **`AutoTypeCodable`**: Expanded documentation and added comprehensive unit tests for property wrappers
- **Test Documentation**: Added documentation to character constants with Unicode references

### Dependencies
- Updated `QizhMacroKit` from `1.1.16` to `1.3.0`
- Added guidelines for handling small changes (`≤42` lines) recommending direct commits instead of PRs